### PR TITLE
fix joint trips and zone ids

### DIFF
--- a/src/processing/add_zone_ids/add_zone_ids.py
+++ b/src/processing/add_zone_ids/add_zone_ids.py
@@ -14,19 +14,23 @@ logger = logging.getLogger(__name__)
 def add_zone_to_dataframe(
     df: pl.DataFrame,
     shp: gpd.GeoDataFrame,
+    df_index: str,
     lon_col: str,
     lat_col: str,
     zone_col_name: str,
     zone_id_field: str,
 ) -> pl.DataFrame:
     """Add zone ID to dataframe based on lon/lat coordinates."""
+    # Convert to GeoDataFrame
+    # Keep just index to avoid corrupting original polars DataFrame with pandas nonsense
     gdf = gpd.GeoDataFrame(
-        df.to_pandas(),
+        index=df[df_index].to_list(),
         geometry=gpd.points_from_xy(df[lon_col].to_list(), df[lat_col].to_list()),
         crs="EPSG:4326",
     )
+    gdf.index.name = df_index
 
-    # Prepare shapefile for spatial join and ensure zone ID is string
+    # Prepare shapefile for spatial join and ensure zone ID is string to handle nulls in pandas land
     shp_prepared = shp.loc[:, [zone_id_field, "geometry"]].copy()
     shp_prepared[zone_id_field] = shp_prepared[zone_id_field].astype(str)
     shp_prepared = shp_prepared.set_index(zone_id_field)
@@ -36,15 +40,31 @@ def add_zone_to_dataframe(
     gdf_joined = gdf_joined.rename(columns={zone_id_field: zone_col_name})
     gdf_joined = gdf_joined.drop(columns="geometry")
 
-    return pl.from_pandas(gdf_joined)
+    # If all zone IDs are integers, convert to Int64 to allow nulls
+    # else keep as string
+    casttype = pl.Utf8
+    if gdf_joined[zone_col_name].dropna().apply(lambda x: x.isdigit()).all():
+        casttype = pl.Int64
+
+    # Join back to original polars DataFrame on index
+    df_joined = df.join(
+        pl.from_pandas(gdf_joined.reset_index()),
+        on=df_index,
+        how="left",
+    ).with_columns(pl.col(zone_col_name).cast(casttype))
+
+    return df_joined
 
 
 @step()
 def add_zone_ids(
-    households: pl.DataFrame,
-    persons: pl.DataFrame,
-    linked_trips: pl.DataFrame,
     zone_geographies: list[dict],
+    households: pl.DataFrame | None = None,
+    persons: pl.DataFrame | None = None,
+    unlinked_trips: pl.DataFrame | None = None,
+    linked_trips: pl.DataFrame | None = None,
+    tours: pl.DataFrame | None = None,
+    joint_trips: pl.DataFrame | None = None,
 ) -> dict:
     """Add zone IDs for multiple geographic levels based on locations.
 
@@ -57,7 +77,10 @@ def add_zone_ids(
     Args:
         households: Households dataframe
         persons: Persons dataframe
+        unlinked_trips: Unlinked trips dataframe
         linked_trips: Linked trips dataframe
+        tours: Tours dataframe
+        joint_trips: Joint trips dataframe
         zone_geographies: List of dicts, each containing:
             - shapefile: Path to shapefile with zone boundaries (str)
             - zone_id_field: Field name in shapefile for zone ID
@@ -66,52 +89,70 @@ def add_zone_ids(
     Returns:
         Dictionary with updated dataframes
     """
+    # Initialize results dictionary in outer scope to update in loop, allow accumulation of zone IDs
     results = {
         "households": households,
         "persons": persons,
+        "unlinked_trips": unlinked_trips,
         "linked_trips": linked_trips,
+        "tours": tours,
+        "joint_trips": joint_trips,
     }
-
     # Process each zone geography
     for zone_config in zone_geographies:
         shapefile_path = zone_config["shapefile"]
         zone_id_field = zone_config["zone_id_field"]
         zone_name = zone_config["zone_name"]
 
-        logger.info(
-            "Adding %s IDs using field '%s' from %s",
-            zone_name.upper(),
-            zone_id_field,
-            shapefile_path,
-        )
-
         # Load the shapefile
         shapefile = gpd.read_file(shapefile_path)
 
-        # Standard location mappings: (table, lon_col, lat_col, location_prefix)
+        # Standard location mappings: (table, table_index, lon_col, lat_col, location_prefix)
         standard_locations = [
-            ("households", "home_lon", "home_lat", "home"),
-            ("persons", "work_lon", "work_lat", "work"),
-            ("persons", "school_lon", "school_lat", "school"),
-            ("linked_trips", "o_lon", "o_lat", "o"),
-            ("linked_trips", "d_lon", "d_lat", "d"),
+            ("households", "hh_id", "home_lon", "home_lat", "home"),
+            ("persons", "person_id", "work_lon", "work_lat", "work"),
+            ("persons", "person_id", "school_lon", "school_lat", "school"),
+            ("unlinked_trips", "trip_id", "o_lon", "o_lat", "o"),
+            ("unlinked_trips", "trip_id", "d_lon", "d_lat", "d"),
+            ("linked_trips", "linked_trip_id", "o_lon", "o_lat", "o"),
+            ("linked_trips", "linked_trip_id", "d_lon", "d_lat", "d"),
+            ("tours", "tour_id", "o_lon", "o_lat", "o"),
+            ("tours", "tour_id", "d_lon", "d_lat", "d"),
+            ("joint_trips", "joint_trip_id", "o_lon_mean", "o_lat_mean", "o"),
+            ("joint_trips", "joint_trip_id", "d_lon_mean", "d_lat_mean", "d"),
         ]
 
         # Apply this zone geography to all standard locations
-        for table, lon_col, lat_col, location_prefix in standard_locations:
+        for table, idx, lon_col, lat_col, location_prefix in standard_locations:
             output_col = f"{location_prefix}_{zone_name}"
 
-            if output_col in results[table].columns:
+            df = results.get(table)
+
+            if df is None:
+                # Make sure its not in results
+                results.pop(table, None)
+                continue  # Skip if no table specified
+
+            logger.info(
+                "Adding %s IDs on table %s using field '%s' from %s",
+                zone_name.upper(),
+                table,
+                zone_id_field,
+                shapefile_path,
+            )
+
+            if output_col in df.columns:
                 logger.warning(
                     "Column %s already exists in %s; replacing it.",
                     output_col,
                     table,
                 )
-                results[table] = results[table].drop(output_col)
+                df = df.drop(output_col)
 
             results[table] = add_zone_to_dataframe(
-                results[table],
+                df,
                 shapefile,
+                df_index=idx,
                 lon_col=lon_col,
                 lat_col=lat_col,
                 zone_col_name=output_col,

--- a/src/processing/joint_trips/detect_joint_trips.py
+++ b/src/processing/joint_trips/detect_joint_trips.py
@@ -9,6 +9,7 @@ import logging
 import polars as pl
 
 from pipeline.decoration import step
+from utils.create_ids import create_concatenated_id
 
 from .aggregation import (
     build_joint_trips_table,
@@ -23,6 +24,161 @@ from .similarity import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _create_empty_results(
+    linked_trips: pl.DataFrame,
+) -> dict[str, pl.DataFrame]:
+    """Create empty result structure when no joint trips are detected."""
+    linked_trips_with_joints = linked_trips.with_columns(
+        [pl.lit(None, dtype=pl.Int64).alias("joint_trip_id")]
+    )
+    empty_joint_trips = pl.DataFrame(
+        schema={
+            "joint_trip_id": pl.Int64,
+            "hh_id": pl.Int64,
+            "day_id": pl.Int64,
+            "num_joint_travelers": pl.Int64,
+            "o_lat_mean": pl.Float64,
+            "o_lon_mean": pl.Float64,
+            "d_lat_mean": pl.Float64,
+            "d_lon_mean": pl.Float64,
+            "min_depart_time": pl.Datetime,
+            "max_arrive_time": pl.Datetime,
+        }
+    )
+    return {
+        "linked_trips": linked_trips_with_joints,
+        "joint_trips": empty_joint_trips,
+    }
+
+
+def _filter_multi_person_households(
+    linked_trips: pl.DataFrame,
+) -> pl.DataFrame:
+    """Pre-filter trips to only those in multi-person households."""
+    persons_per_hh = linked_trips.group_by(["hh_id"]).agg(
+        [pl.col("person_id").n_unique().alias("n_persons")]
+    )
+    multi_person_hhs = persons_per_hh.filter(
+        pl.col("n_persons") >= 2  # noqa: PLR2004
+    )
+    candidate_trips = linked_trips.join(
+        multi_person_hhs.select(["hh_id"]),
+        on="hh_id",
+        how="inner",
+    )
+    num_excluded = len(linked_trips) - len(candidate_trips)
+    logger.info(
+        "Pre-filter: %d trips in multi-person households (%d single-person trips excluded)",
+        len(candidate_trips),
+        num_excluded,
+    )
+    return candidate_trips
+
+
+def _create_and_filter_trip_pairs(
+    candidate_trips: pl.DataFrame,
+) -> pl.DataFrame:
+    """Create trip pairs and apply deduplication and temporal filters."""
+    # Self-join within household to create trip pairs
+    trip_pairs = candidate_trips.join(
+        candidate_trips.select(
+            [
+                "hh_id",
+                "linked_trip_id",
+                "person_id",
+                "o_lat",
+                "o_lon",
+                "d_lat",
+                "d_lon",
+                "depart_time",
+                "arrive_time",
+            ]
+        ).rename(
+            {
+                "linked_trip_id": "linked_trip_id_b",
+                "person_id": "person_id_b",
+                "o_lat": "o_lat_b",
+                "o_lon": "o_lon_b",
+                "d_lat": "d_lat_b",
+                "d_lon": "d_lon_b",
+                "depart_time": "depart_time_b",
+                "arrive_time": "arrive_time_b",
+            }
+        ),
+        on=["hh_id"],
+        how="inner",
+    )
+
+    logger.info(
+        "Created %s candidate trip pairs (before deduplication)",
+        f"{len(trip_pairs):,}",
+    )
+
+    # Remove self-pairs (same trip or same person)
+    trip_pairs = trip_pairs.filter(
+        # Remove same trip
+        (pl.col("linked_trip_id") != pl.col("linked_trip_id_b"))
+        # Remove same person but different trips
+        & (pl.col("person_id") != pl.col("person_id_b"))
+        # Deduplicate by keeping only one direction (A->B, not B->A)
+        & (pl.col("linked_trip_id") < pl.col("linked_trip_id_b"))
+    )
+
+    logger.info("After deduplication: %s pairs", f"{len(trip_pairs):,}")
+
+    # Apply temporal overlap filter
+    trip_pairs = trip_pairs.filter(
+        pl.max_horizontal("depart_time", "depart_time_b")
+        <= pl.min_horizontal("arrive_time", "arrive_time_b")
+    )
+
+    logger.info("After temporal overlap filter: %d pairs", len(trip_pairs))
+    return trip_pairs
+
+
+def _assign_joint_trip_ids(
+    clique_assignments: pl.DataFrame,
+    linked_trips: pl.DataFrame,
+) -> pl.DataFrame:
+    """Convert clique IDs to standardized joint_trip_ids."""
+    # Join clique_id with household info
+    cliques_with_hh = clique_assignments.join(
+        linked_trips.select(["linked_trip_id", "hh_id"]),
+        on="linked_trip_id",
+        how="left",
+    ).filter(pl.col("clique_id").is_not_null())
+
+    if len(cliques_with_hh) == 0:
+        # No cliques found, just add null joint_trip_id column
+        return clique_assignments.drop("clique_id").with_columns(
+            pl.lit(None, dtype=pl.Int64).alias("joint_trip_id")
+        )
+
+    # Group by clique_id to get household and create enumerators
+    clique_to_hh = cliques_with_hh.group_by("clique_id").agg([pl.col("hh_id").first()])
+
+    # Create household-scoped enumerators
+    clique_to_hh = clique_to_hh.with_columns(
+        pl.col("clique_id").rank(method="dense").over("hh_id").alias("joint_trip_num")
+    )
+
+    # Create standardized joint_trip_id: <hh_id> + <3 digit enumerator>
+    clique_to_hh = create_concatenated_id(
+        clique_to_hh,
+        output_col="joint_trip_id",
+        parent_id_col="hh_id",
+        sequence_col="joint_trip_num",
+        sequence_padding=3,
+    )
+
+    # Join joint_trip_id back to assignments
+    return clique_assignments.join(
+        clique_to_hh.select(["clique_id", "joint_trip_id"]),
+        on="clique_id",
+        how="left",
+    ).drop("clique_id")
 
 
 @step()
@@ -82,134 +238,23 @@ def detect_joint_trips(
     )
 
     # Pre-filter to household with 2+ persons
-    persons_per_hh = linked_trips.group_by(["hh_id"]).agg(
-        [pl.col("person_id").n_unique().alias("n_persons")]
-    )
-
-    multi_person_hhs = persons_per_hh.filter(
-        pl.col("n_persons") >= 2  # noqa: PLR2004
-    )
-
-    candidate_trips = linked_trips.join(
-        multi_person_hhs.select(["hh_id"]),
-        on="hh_id",
-        how="inner",
-    )
-
-    num_excluded = len(linked_trips) - len(candidate_trips)
-    logger.info(
-        "Pre-filter: %d trips in multi-person households (%d single-person trips excluded)",
-        len(candidate_trips),
-        num_excluded,
-    )
+    candidate_trips = _filter_multi_person_households(linked_trips)
 
     if len(candidate_trips) == 0:
         logger.warning(
             "No multi-person households found. No joint trips possible, returning empty results."
         )
-        linked_trips_with_joints = linked_trips.with_columns(
-            [pl.lit(None, dtype=pl.Int64).alias("joint_trip_id")]
-        )
-        empty_joint_trips = pl.DataFrame(
-            schema={
-                "joint_trip_id": pl.Int64,
-                "hh_id": pl.Int64,
-                "day_id": pl.Int64,
-                "num_joint_travelers": pl.Int64,
-                "o_lat_mean": pl.Float64,
-                "o_lon_mean": pl.Float64,
-                "d_lat_mean": pl.Float64,
-                "d_lon_mean": pl.Float64,
-                "min_depart_time": pl.Datetime,
-                "max_arrive_time": pl.Datetime,
-            }
-        )
-        return {
-            "linked_trips": linked_trips_with_joints,
-            "joint_trips": empty_joint_trips,
-        }
+        return _create_empty_results(linked_trips)
 
-    # Self-join within household-day to create trip pairs
-    trip_pairs = candidate_trips.join(
-        candidate_trips.select(
-            [
-                "hh_id",
-                "linked_trip_id",
-                "person_id",
-                "o_lat",
-                "o_lon",
-                "d_lat",
-                "d_lon",
-                "depart_time",
-                "arrive_time",
-            ]
-        ).rename(
-            {
-                "linked_trip_id": "linked_trip_id_b",
-                "person_id": "person_id_b",
-                "o_lat": "o_lat_b",
-                "o_lon": "o_lon_b",
-                "d_lat": "d_lat_b",
-                "d_lon": "d_lon_b",
-                "depart_time": "depart_time_b",
-                "arrive_time": "arrive_time_b",
-            }
-        ),
-        on=["hh_id"],
-        how="inner",
-    )
-
-    logger.info(
-        "Created %s candidate trip pairs (before deduplication)",
-        f"{len(trip_pairs):,}",
-    )
-
-    # Remove self-pairs (same trip or same person)
-    trip_pairs = trip_pairs.filter(
-        # Remove same trip
-        (pl.col("linked_trip_id") != pl.col("linked_trip_id_b"))
-        # Remove same person but different trips
-        & (pl.col("person_id") != pl.col("person_id_b"))
-        # Deduplicate by keeping only one direction (A->B, not B->A)
-        & (pl.col("linked_trip_id") < pl.col("linked_trip_id_b"))
-    )
-
-    logger.info("After deduplication: %s pairs", f"{len(trip_pairs):,}")
-
-    # Apply temporal overlap filter
-    trip_pairs = trip_pairs.filter(
-        pl.max_horizontal("depart_time", "depart_time_b")
-        <= pl.min_horizontal("arrive_time", "arrive_time_b")
-    )
-
-    logger.info("After temporal overlap filter: %d pairs", len(trip_pairs))
+    # Create trip pairs and apply filters
+    trip_pairs = _create_and_filter_trip_pairs(candidate_trips)
 
     if len(trip_pairs) == 0:
         logger.warning(
             "No temporally overlapping trip pairs found. "
             "No joint trips detected, consider checking data quality."
         )
-        linked_trips_with_joints = linked_trips.with_columns(
-            [pl.lit(None, dtype=pl.Int64).alias("joint_trip_id")]
-        )
-        empty_joint_trips = pl.DataFrame(
-            schema={
-                "joint_trip_id": pl.Int64,
-                "hh_id": pl.Int64,
-                "day_id": pl.Int64,
-                "num_joint_travelers": pl.Int64,
-                "o_lat_mean": pl.Float64,
-                "o_lon_mean": pl.Float64,
-                "d_lat_mean": pl.Float64,
-                "d_lon_mean": pl.Float64,
-                "min_depart_time": pl.Datetime,
-                "max_arrive_time": pl.Datetime,
-            }
-        )
-        return {
-            "linked_trips": linked_trips_with_joints,
-            "joint_trips": empty_joint_trips,
-        }
+        return _create_empty_results(linked_trips)
 
     # Compute pairwise distances
     trip_pairs = compute_pairwise_distances(trip_pairs)
@@ -233,31 +278,12 @@ def detect_joint_trips(
             "No joint trips detected. Consider relaxing thresholds or "
             "checking data quality (GPS accuracy, time synchronization)."
         )
-        linked_trips_with_joints = linked_trips.with_columns(
-            [pl.lit(None, dtype=pl.Int64).alias("joint_trip_id")]
-        )
-        empty_joint_trips = pl.DataFrame(
-            schema={
-                "joint_trip_id": pl.Int64,
-                "hh_id": pl.Int64,
-                "day_id": pl.Int64,
-                "num_joint_travelers": pl.Int64,
-                "o_lat_mean": pl.Float64,
-                "o_lon_mean": pl.Float64,
-                "d_lat_mean": pl.Float64,
-                "d_lon_mean": pl.Float64,
-                "min_depart_time": pl.Datetime,
-                "max_arrive_time": pl.Datetime,
-            }
-        )
-        return {
-            "linked_trips": linked_trips_with_joints,
-            "joint_trips": empty_joint_trips,
-        }
+        return _create_empty_results(linked_trips)
 
     # Detect joint trips using clique detection
-    joint_trip_assignments, flagged_conflicts = detect_disjoint_cliques(
-        filtered_pairs, linked_trips.select("linked_trip_id").to_series()
+    clique_assignments, flagged_conflicts = detect_disjoint_cliques(
+        filtered_pairs,
+        linked_trips.select("linked_trip_id").to_series(),
     )
 
     # Log flagged conflicts if any
@@ -270,6 +296,9 @@ def detect_joint_trips(
             # Show first 5 flagged conflicts
             for i, clique in enumerate(flagged_conflicts[:5], 1):
                 logger.debug("Flagged clique %d: trips %s", i, clique)
+
+    # Convert clique_id to standardized joint_trip_id
+    joint_trip_assignments = _assign_joint_trip_ids(clique_assignments, linked_trips)
 
     # Join assignments back to linked_trips
     linked_trips_with_joints = linked_trips.join(

--- a/tests/test_add_zone_ids.py
+++ b/tests/test_add_zone_ids.py
@@ -35,6 +35,7 @@ class TestAddZoneToDataframe:
 
         result = add_zone_to_dataframe(
             df=df,
+            df_index="id",
             shp=zones_gdf,
             lon_col="lon",
             lat_col="lat",
@@ -65,6 +66,7 @@ class TestAddZoneToDataframe:
 
         result = add_zone_to_dataframe(
             df=df,
+            df_index="id",
             shp=zones_gdf,
             lon_col="lon",
             lat_col="lat",
@@ -94,6 +96,7 @@ class TestAddZoneToDataframe:
 
         result = add_zone_to_dataframe(
             df=df,
+            df_index="id",
             shp=zones_gdf,
             lon_col="lon",
             lat_col="lat",
@@ -125,6 +128,7 @@ class TestAddZoneToDataframe:
 
         result = add_zone_to_dataframe(
             df=df,
+            df_index="id",
             shp=zones_gdf,
             lon_col="lon",
             lat_col="lat",
@@ -132,8 +136,8 @@ class TestAddZoneToDataframe:
             zone_id_field="zone_id",
         )
 
-        # Should be string "100", not integer 100
-        assert result["zone"][0] == "100"
+        # Should be integer
+        assert result["zone"][0] == 100
 
 
 class TestAddZoneIds:
@@ -209,7 +213,7 @@ class TestAddZoneIds:
         result = add_zone_ids(
             households=sample_households,
             persons=sample_persons,
-            linked_trips=sample_trips,
+            unlinked_trips=sample_trips,
             zone_geographies=zone_geographies,
         )
 
@@ -225,10 +229,10 @@ class TestAddZoneIds:
         assert result["persons"]["school_taz"][2] == "TAZ3"
 
         # Check trips has o_taz and d_taz
-        assert "o_taz" in result["linked_trips"].columns
-        assert "d_taz" in result["linked_trips"].columns
-        assert result["linked_trips"]["o_taz"][0] == "TAZ1"
-        assert result["linked_trips"]["d_taz"][1] == "TAZ3"
+        assert "o_taz" in result["unlinked_trips"].columns
+        assert "d_taz" in result["unlinked_trips"].columns
+        assert result["unlinked_trips"]["o_taz"][0] == "TAZ1"
+        assert result["unlinked_trips"]["d_taz"][1] == "TAZ3"
 
     def test_add_multiple_zone_geographies(
         self, sample_households, sample_persons, sample_trips, tmp_path
@@ -262,7 +266,7 @@ class TestAddZoneIds:
         result = add_zone_ids(
             households=sample_households,
             persons=sample_persons,
-            linked_trips=sample_trips,
+            unlinked_trips=sample_trips,
             zone_geographies=zone_geographies,
         )
 
@@ -290,7 +294,7 @@ class TestAddZoneIds:
         result = add_zone_ids(
             households=sample_households,
             persons=sample_persons,
-            linked_trips=sample_trips,
+            unlinked_trips=sample_trips,
             zone_geographies=zone_geographies,
         )
 
@@ -313,14 +317,14 @@ class TestAddZoneIds:
         result = add_zone_ids(
             households=sample_households,
             persons=sample_persons,
-            linked_trips=sample_trips,
+            unlinked_trips=sample_trips,
             zone_geographies=zone_geographies,
         )
 
         # Original columns should still exist
         assert "hh_id" in result["households"].columns
         assert "person_id" in result["persons"].columns
-        assert "trip_id" in result["linked_trips"].columns
+        assert "trip_id" in result["unlinked_trips"].columns
         assert "home_lon" in result["households"].columns
 
     def test_returns_all_three_tables(
@@ -338,13 +342,13 @@ class TestAddZoneIds:
         result = add_zone_ids(
             households=sample_households,
             persons=sample_persons,
-            linked_trips=sample_trips,
+            unlinked_trips=sample_trips,
             zone_geographies=zone_geographies,
         )
 
         assert "households" in result
         assert "persons" in result
-        assert "linked_trips" in result
+        assert "unlinked_trips" in result
         assert isinstance(result["households"], pl.DataFrame)
         assert isinstance(result["persons"], pl.DataFrame)
-        assert isinstance(result["linked_trips"], pl.DataFrame)
+        assert isinstance(result["unlinked_trips"], pl.DataFrame)


### PR DESCRIPTION
another small incremental fix to declutter other PRs

### Clique detection output renamed + semantics clarified
**Files:** `src/processing/joint_trips/clique_detection.py`  
- Renamed the assignment output column from `joint_trip_id` → `clique_id`.
  - Docstring and empty-result schemas updated accordingly.
- Updated internal mapping/variable names to match clique semantics:
  - `trip_to_joint` → `trip_to_clique_id`
  - `joint_trip_assignments` → `clique_assignments`
- Changed clique ID assignment to **simple sequential clique identifiers** derived from enumeration of `disjoint_cliques`.
- Updated logging language to reflect clique terminology:
  - “joint groups” → “cliques”

---

### Joint trip detection refactor + standardized ID generation
**Files:** `src/processing/joint_trips/detect_joint_trips.py`  
- Refactored `detect_joint_trips` into smaller helpers for readability and reuse:
  - `_create_empty_results(...)`: centralized “no joint trips” return structure (adds null `joint_trip_id` + empty `joint_trips` table schema).
  - `_filter_multi_person_households(...)`: isolates the multi-person HH prefilter and logging.
  - `_create_and_filter_trip_pairs(...)`: encapsulates trip-pair creation, deduplication, and temporal overlap filtering.
  - `_assign_joint_trip_ids(...)`: **converts raw `clique_id` assignments into standardized `joint_trip_id`s**.
- Standardized `joint_trip_id` construction to be **household-scoped and stable**:
  - Joins `clique_id` assignments to `hh_id`.
  - Filters to non-null cliques before ID generation.
  - Uses dense ranking within each household to create an enumerator (`joint_trip_num`).
  - Builds IDs using `create_concatenated_id(...)` as: `<hh_id>` + `<3-digit sequence>` (padding=3).
- Updated the clique detection integration:
  - `detect_disjoint_cliques(...)` now returns `clique_assignments` with `clique_id`.
  - Added conversion step to generate final `joint_trip_id` assignments before joining back to `linked_trips`.
- Simplified early-exit paths:
  - Multi-person HH absence, no overlapping pairs, or no filtered pairs all route through `_create_empty_results(...)`.
