### PR TITLE
pass through distance from survey

### DIFF
--- a/src/data_canon/models/ctramp.py
+++ b/src/data_canon/models/ctramp.py
@@ -224,6 +224,20 @@ class MandatoryLocationCTRAMPModel(BaseModel):
         default=None,
         description="Walk to transit work sub-zone (0=cannot walk to transit; 1=short-walk; 2=long-walk)",
     )
+    work_distance_survey: float | None = Field(
+        default=None,
+        ge=0,
+        description="""
+        Survey-reported home to work distance in miles calculated as average traveled distance to work
+        (for validation, not part of CT-RAMP spec)""",
+    )
+    school_distance_survey: float | None = Field(
+        default=None,
+        ge=0,
+        description="""
+        Survey-reported home to school distance in miles calculated as average traveled distance to school
+        (for validation, not part of CT-RAMP spec)""",
+    )
 
 
 class IndividualTourCTRAMPModel(BaseModel):
@@ -408,6 +422,11 @@ class IndividualTripCTRAMPModel(BaseModel):
         default=None,
         ge=0,
         description="Survey weight for the trip, aka linked_trip_weight (not part of CT-RAMP spec)",
+    )
+    distance_survey: float | None = Field(
+        default=None,
+        ge=0,
+        description="Survey-reported trip distance in miles (for validation, not part of CT-RAMP spec)",
     )
 
 

--- a/src/processing/formatting/ctramp/ctramp_config.py
+++ b/src/processing/formatting/ctramp/ctramp_config.py
@@ -85,6 +85,16 @@ class CTRAMPConfig(BaseModel):
         ),
     )
 
+    # spatial buffer (meters) for matching fixed locations to trip destinations
+    fixed_location_buffer_meters: float = Field(
+        default=200.0,
+        ge=0,
+        description=(
+            "Spatial buffer in meters for matching fixed work/school "
+            "locations to trip destinations when calculating distances."
+        ),
+    )
+
     @model_validator(mode="after")
     def validate_income_ordering(self) -> "CTRAMPConfig":
         """Validate that income thresholds are in proper order."""

--- a/src/processing/formatting/ctramp/ctramp_config.py
+++ b/src/processing/formatting/ctramp/ctramp_config.py
@@ -95,6 +95,13 @@ class CTRAMPConfig(BaseModel):
         ),
     )
 
+    # Distance units
+    distance_unit: str = Field(
+        default="miles",
+        pattern="^(miles|kilometers|meters)$",
+        description="Distance unit for CT-RAMP formatting ('miles', 'kilometers', or 'meters').",
+    )
+
     @model_validator(mode="after")
     def validate_income_ordering(self) -> "CTRAMPConfig":
         """Validate that income thresholds are in proper order."""

--- a/src/processing/formatting/ctramp/format_ctramp.py
+++ b/src/processing/formatting/ctramp/format_ctramp.py
@@ -322,6 +322,7 @@ def format_ctramp(
     mandatory_location_ctramp = format_mandatory_location(
         persons_ctramp=persons_ctramp,
         households_ctramp=households_ctramp,
+        linked_trips_canonical=linked_trips,
         config=config,
     )
 

--- a/src/processing/formatting/ctramp/format_mandatory_location.py
+++ b/src/processing/formatting/ctramp/format_mandatory_location.py
@@ -4,14 +4,169 @@ import logging
 
 import polars as pl
 
+from utils.helpers import expr_haversine
+
 from .ctramp_config import CTRAMPConfig
 
 logger = logging.getLogger(__name__)
 
 
+def calc_fixed_location_distances(
+    mandatory_locations: pl.DataFrame,
+    linked_trips_canonical: pl.DataFrame,
+    buffer: float = 500,
+    fixed_type: str = "work",
+    unit: str = "miles",
+) -> pl.DataFrame:
+    """Calculate fixed work/school location distances for validation.
+
+    Args:
+        mandatory_locations: DataFrame with person fixed locations and home locations
+        linked_trips_canonical: Canonical linked trips DataFrame with trip origins/destinations
+        buffer: Distance buffer in meters to consider a trip origin/destination
+            as being at home or at the fixed location
+        fixed_type: Type of fixed location to calculate distances for ("work" or "school")
+        unit: Unit for returned distances ("miles" or "meters")
+
+    Returns:
+        DataFrame with person_id and calculated work/school distances
+    """
+    if fixed_type not in ["work", "school"]:
+        msg = "fixed_type must be 'work' or 'school'"
+        raise ValueError(msg)
+
+    if unit not in ["miles", "meters"]:
+        msg = "unit must be 'miles' or 'meters'"
+        raise ValueError(msg)
+
+    # Filter persons to fixed locations for the type we are calculating
+    _mandatory_locations = mandatory_locations.filter(
+        pl.col(f"{fixed_type}_lat").is_not_null() & pl.col(f"{fixed_type}_lon").is_not_null()
+    )
+
+    logger.info(
+        "Calculated fixed location distances for %d persons",
+        _mandatory_locations.select("person_id").n_unique(),
+    )
+
+    # Join trips with person fixed locations
+    trips_with_locations = linked_trips_canonical.join(
+        _mandatory_locations.select(
+            "person_id",
+            "home_lat",
+            "home_lon",
+            f"{fixed_type}_lat",
+            f"{fixed_type}_lon",
+            f"{fixed_type}_taz",
+        ),
+        on="person_id",
+        how="right",
+    )
+
+    # Calculate flags for origin/destination proximity
+    trips_with_flags = trips_with_locations.with_columns(
+        [
+            (
+                expr_haversine(
+                    pl.col("o_lat"),
+                    pl.col("o_lon"),
+                    pl.col("home_lat"),
+                    pl.col("home_lon"),
+                    units="meters",
+                )
+                <= buffer
+            ).alias("origin_is_home"),
+            (
+                expr_haversine(
+                    pl.col("o_lat"),
+                    pl.col("o_lon"),
+                    pl.col(f"{fixed_type}_lat"),
+                    pl.col(f"{fixed_type}_lon"),
+                    units="meters",
+                )
+                <= buffer
+            ).alias(f"origin_is_{fixed_type}"),
+            (
+                expr_haversine(
+                    pl.col("d_lat"),
+                    pl.col("d_lon"),
+                    pl.col("home_lat"),
+                    pl.col("home_lon"),
+                    units="meters",
+                )
+                <= buffer
+            ).alias("dest_is_home"),
+            (
+                expr_haversine(
+                    pl.col("d_lat"),
+                    pl.col("d_lon"),
+                    pl.col(f"{fixed_type}_lat"),
+                    pl.col(f"{fixed_type}_lon"),
+                    units="meters",
+                )
+                <= buffer
+            ).alias(f"dest_is_{fixed_type}"),
+            # Calculate matching TAZs for origin/destination, used as fallback
+            (pl.col("o_taz") == pl.col(f"{fixed_type}_taz")).alias(f"origin_is_{fixed_type}_taz"),
+            (pl.col("d_taz") == pl.col(f"{fixed_type}_taz")).alias(f"dest_is_{fixed_type}_taz"),
+        ]
+    )
+
+    # Filter for home-work or work-home trips within buffer and ignore direction
+    # i.e., trips that start or end at home and the other end at the fixed location
+    home_to_fixed_trips = trips_with_flags.filter(
+        (
+            (pl.col("origin_is_home") & pl.col(f"dest_is_{fixed_type}"))
+            | (pl.col(f"origin_is_{fixed_type}") & pl.col("dest_is_home"))
+        )
+        # Fallback to use matching TAZs
+        | (pl.col("origin_is_" + fixed_type + "_taz") & pl.col("dest_is_home"))
+        | (pl.col("dest_is_" + fixed_type + "_taz") & pl.col("origin_is_home"))
+    )
+
+    # Extract and average the distance field for these trips
+    distances = home_to_fixed_trips.group_by("person_id").agg(
+        pl.col("distance_meters").mean().alias(f"{fixed_type}_distance_meters")
+    )
+
+    # Check and warn for any missing distances due to no matching trips
+    missing_distance_persons = (
+        _mandatory_locations.join(distances, on="person_id", how="left")
+        .filter(pl.col(f"{fixed_type}_distance_meters").is_null())
+        .select(
+            "person_id",
+            "home_lat",
+            "home_lon",
+            f"{fixed_type}_lat",
+            f"{fixed_type}_lon",
+        )
+    )
+
+    if missing_distance_persons.height > 0:
+        logger.warning(
+            (
+                "Found no matching trips for %d persons with a reported fixed %s locations, "
+                "leaving %s_distance_meters as null"
+            ),
+            missing_distance_persons.height,
+            fixed_type,
+            f"{fixed_type}_distance_meters",
+        )
+
+    # If unit is miles, convert from meters
+    if unit == "miles":
+        distances = distances.with_columns(
+            (pl.col(f"{fixed_type}_distance_meters") / 1609.34).alias(
+                f"{fixed_type}_distance_miles"
+            )
+        ).select(["person_id", f"{fixed_type}_distance_miles"])
+    return distances
+
+
 def format_mandatory_location(
     persons_ctramp: pl.DataFrame,
     households_ctramp: pl.DataFrame,
+    linked_trips_canonical: pl.DataFrame,
     config: CTRAMPConfig,
 ) -> pl.DataFrame:
     """Format mandatory locations (work/school) to CT-RAMP specification.
@@ -25,6 +180,7 @@ def format_mandatory_location(
             student_category, work_taz, school_taz
         households_ctramp: Formatted CT-RAMP households DataFrame with hh_id, income,
             home_taz (for HomeTAZ field)
+        linked_trips_canonical: Canonical linked trips DataFrame for distance calculations
         config: CT-RAMP configuration with income_base_year_dollars
 
     Returns:
@@ -42,9 +198,11 @@ def format_mandatory_location(
     """
     logger.info("Formatting mandatory location data for CT-RAMP")
 
-    # Join persons with households to get income and home TAZ
+    # Join persons with households to get income and home TAZ, lat/lon
     mandatory_loc = persons_ctramp.join(
-        households_ctramp.select(["hh_id", f"home_{config.taz_field}", "income"]),
+        households_ctramp.select(
+            ["hh_id", f"home_{config.taz_field}", "home_lat", "home_lon", "income"]
+        ),
         on="hh_id",
         how="left",
     )
@@ -71,6 +229,21 @@ def format_mandatory_location(
         )
     )
 
+    # Calculate fixed work/school distances for validation for persons that have fixed locations
+    for fixed_type in ["work", "school"]:
+        distances_df = calc_fixed_location_distances(
+            mandatory_locations=mandatory_loc,
+            linked_trips_canonical=linked_trips_canonical,
+            buffer=config.fixed_location_buffer_meters,
+            fixed_type=fixed_type,
+            unit="miles",
+        )
+        mandatory_loc = mandatory_loc.join(
+            distances_df,
+            on="person_id",
+            how="left",
+        ).rename({f"{fixed_type}_distance_miles": f"{fixed_type}_distance_survey"})
+
     # Map to CT-RAMP column names
     mandatory_loc = mandatory_loc.select(
         [
@@ -88,6 +261,8 @@ def format_mandatory_location(
             .fill_null(0)
             .cast(pl.Int64)
             .alias("SchoolLocation"),
+            "work_distance_survey",
+            "school_distance_survey",
         ]
     )
 

--- a/src/processing/formatting/ctramp/format_mandatory_location.py
+++ b/src/processing/formatting/ctramp/format_mandatory_location.py
@@ -14,19 +14,16 @@ logger = logging.getLogger(__name__)
 def calc_fixed_location_distances(
     mandatory_locations: pl.DataFrame,
     linked_trips_canonical: pl.DataFrame,
-    buffer: float = 500,
-    fixed_type: str = "work",
-    unit: str = "miles",
+    fixed_type: str,
+    config: CTRAMPConfig,
 ) -> pl.DataFrame:
     """Calculate fixed work/school location distances for validation.
 
     Args:
         mandatory_locations: DataFrame with person fixed locations and home locations
         linked_trips_canonical: Canonical linked trips DataFrame with trip origins/destinations
-        buffer: Distance buffer in meters to consider a trip origin/destination
-            as being at home or at the fixed location
         fixed_type: Type of fixed location to calculate distances for ("work" or "school")
-        unit: Unit for returned distances ("miles" or "meters")
+        config: CT-RAMP configuration with fixed location buffer and distance unit
 
     Returns:
         DataFrame with person_id and calculated work/school distances
@@ -35,14 +32,28 @@ def calc_fixed_location_distances(
         msg = "fixed_type must be 'work' or 'school'"
         raise ValueError(msg)
 
-    if unit not in ["miles", "meters"]:
-        msg = "unit must be 'miles' or 'meters'"
+    if config.distance_unit not in ["miles", "kilometers", "meters"]:
+        msg = "distance_unit must be 'miles', 'kilometers', or 'meters'"
+        raise ValueError(msg)
+
+    if config.fixed_location_buffer_meters is None:
+        msg = "fixed_location_buffer_meters must be set in config"
         raise ValueError(msg)
 
     # Filter persons to fixed locations for the type we are calculating
     _mandatory_locations = mandatory_locations.filter(
         pl.col(f"{fixed_type}_lat").is_not_null() & pl.col(f"{fixed_type}_lon").is_not_null()
     )
+
+    # If nothing to calculate, return empty DataFrame
+    if _mandatory_locations.height == 0:
+        logger.info("No persons with fixed %s locations to calculate distances for", fixed_type)
+        return pl.DataFrame(
+            schema={
+                "person_id": pl.Int64,
+                f"{fixed_type}_distance_{config.distance_unit}": pl.Float64,
+            }
+        )
 
     logger.info(
         "Calculated fixed location distances for %d persons",
@@ -74,7 +85,7 @@ def calc_fixed_location_distances(
                     pl.col("home_lon"),
                     units="meters",
                 )
-                <= buffer
+                <= config.fixed_location_buffer_meters
             ).alias("origin_is_home"),
             (
                 expr_haversine(
@@ -84,7 +95,7 @@ def calc_fixed_location_distances(
                     pl.col(f"{fixed_type}_lon"),
                     units="meters",
                 )
-                <= buffer
+                <= config.fixed_location_buffer_meters
             ).alias(f"origin_is_{fixed_type}"),
             (
                 expr_haversine(
@@ -94,7 +105,7 @@ def calc_fixed_location_distances(
                     pl.col("home_lon"),
                     units="meters",
                 )
-                <= buffer
+                <= config.fixed_location_buffer_meters
             ).alias("dest_is_home"),
             (
                 expr_haversine(
@@ -104,11 +115,15 @@ def calc_fixed_location_distances(
                     pl.col(f"{fixed_type}_lon"),
                     units="meters",
                 )
-                <= buffer
+                <= config.fixed_location_buffer_meters
             ).alias(f"dest_is_{fixed_type}"),
             # Calculate matching TAZs for origin/destination, used as fallback
-            (pl.col("o_taz") == pl.col(f"{fixed_type}_taz")).alias(f"origin_is_{fixed_type}_taz"),
-            (pl.col("d_taz") == pl.col(f"{fixed_type}_taz")).alias(f"dest_is_{fixed_type}_taz"),
+            (pl.col(f"o_{config.taz_field}") == pl.col(f"{fixed_type}_taz")).alias(
+                f"origin_is_{fixed_type}_taz"
+            ),
+            (pl.col(f"d_{config.taz_field}") == pl.col(f"{fixed_type}_taz")).alias(
+                f"dest_is_{fixed_type}_taz"
+            ),
         ]
     )
 
@@ -120,8 +135,8 @@ def calc_fixed_location_distances(
             | (pl.col(f"origin_is_{fixed_type}") & pl.col("dest_is_home"))
         )
         # Fallback to use matching TAZs
-        | (pl.col("origin_is_" + fixed_type + "_taz") & pl.col("dest_is_home"))
-        | (pl.col("dest_is_" + fixed_type + "_taz") & pl.col("origin_is_home"))
+        | (pl.col(f"origin_is_{fixed_type}_taz") & pl.col("dest_is_home"))
+        | (pl.col(f"dest_is_{fixed_type}_taz") & pl.col("origin_is_home"))
     )
 
     # Extract and average the distance field for these trips
@@ -154,12 +169,19 @@ def calc_fixed_location_distances(
         )
 
     # If unit is miles, convert from meters
-    if unit == "miles":
+    if config.distance_unit == "miles":
         distances = distances.with_columns(
             (pl.col(f"{fixed_type}_distance_meters") / 1609.34).alias(
                 f"{fixed_type}_distance_miles"
             )
         ).select(["person_id", f"{fixed_type}_distance_miles"])
+    elif config.distance_unit == "kilometers":
+        distances = distances.with_columns(
+            (pl.col(f"{fixed_type}_distance_meters") / 1000).alias(
+                f"{fixed_type}_distance_kilometers"
+            )
+        ).select(["person_id", f"{fixed_type}_distance_kilometers"])
+
     return distances
 
 
@@ -201,7 +223,7 @@ def format_mandatory_location(
     # Join persons with households to get income and home TAZ, lat/lon
     mandatory_loc = persons_ctramp.join(
         households_ctramp.select(
-            ["hh_id", f"home_{config.taz_field}", "home_lat", "home_lon", "income"]
+            ["hh_id", "home_lat", "home_lon", f"home_{config.taz_field}", "income"]
         ),
         on="hh_id",
         how="left",
@@ -234,15 +256,14 @@ def format_mandatory_location(
         distances_df = calc_fixed_location_distances(
             mandatory_locations=mandatory_loc,
             linked_trips_canonical=linked_trips_canonical,
-            buffer=config.fixed_location_buffer_meters,
             fixed_type=fixed_type,
-            unit="miles",
+            config=config,
         )
         mandatory_loc = mandatory_loc.join(
             distances_df,
             on="person_id",
             how="left",
-        ).rename({f"{fixed_type}_distance_miles": f"{fixed_type}_distance_survey"})
+        ).rename({f"{fixed_type}_distance_{config.distance_unit}": f"{fixed_type}_distance_survey"})
 
     # Map to CT-RAMP column names
     mandatory_loc = mandatory_loc.select(

--- a/src/processing/formatting/ctramp/format_trips.py
+++ b/src/processing/formatting/ctramp/format_trips.py
@@ -167,6 +167,11 @@ def format_individual_trip(
         ]
     )
 
+    # Add survey distance
+    individual_trips = individual_trips.with_columns(
+        (pl.col("distance_meters") / 1609.34).alias("distance_survey")
+    )
+
     # Ensure required columns are formatted and cast to correct types
     individual_trips_ctramp = individual_trips.with_columns(
         [


### PR DESCRIPTION
## Description
Pretty straight forward, this pull request adds new survey-based distance validation fields to the CT-RAMP data models and formatting pipeline. 

- Added new fields to `MandatoryLocationCTRAMPModel` and `IndividualTripCTRAMPModel` to store survey-reported distance
  - `distance_survey` added to `IndividualTripCTRAMPModel` is a simple pass-through from the survey's `distance_meters` but converted to *mile*
  - `distance_work_survey` added to `MandatoryLocationCTRAMPModel`. It calculates this value as the average distance for all trips to/from that fixed location to/from home.

**Caveat!**
I found a small-ish share (like 1,800 persons) that have a reported work_lat/lon but never took any trips to that stated work location.

1152/1802 reported "Work remotely some days and travel to a work location some days", and maybe just never went to the office during the survey period.

The remaining 650 persons reported "Go to one work location ONLY (outside of home)" and 175/650 are Part-time. So there's about 475 that say they work full time and always at the same place, and yet never went there. Can't explain it without further digging.

For now just leaving as NULL and we can decide how to handle them downstream.



## Type of Change
<!-- Check all that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass
- [x] Added new tests to cover changes
- [x] Manually tested the changes

## Checklist
<!-- Check all that apply -->
- [x] My code follows the style guidelines of this project (runs `ruff check .` without errors)
- [x] My code is properly formatted (runs `ruff format .`)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Related Issues
<!-- Link any related issues here using #issue_number -->
Closes #24 