### PR TITLE
enum helper refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,8 +261,8 @@ steps:
   - name: link_trips
     validate: true
     params:
-      change_mode_code: 11  # Purpose code for 'change_mode'
-      transit_mode_codes: [12, 13, 14]
+      change_mode_enum: 11  # Purpose code for 'change_mode'
+      transit_mode_enums: [12, 13, 14]
       max_dwell_time: 180  # in minutes
       dwell_buffer_distance: 100  # in meters
 

--- a/projects/bats_2019/config.yaml
+++ b/projects/bats_2019/config.yaml
@@ -37,8 +37,8 @@ steps:
     validate_input: true
     cache: true
     params:
-      change_mode_code: 11  # Purpose code for 'change_mode'
-      transit_mode_codes: [12, 13, 14] # NOTE: this is not elegant
+      change_mode_enum: CHANGE_MODE
+      transit_mode_enums: [FERRY, TRANSIT, LONG_DISTANCE]
       max_dwell_time: 180  # in minutes
       dwell_buffer_distance: 100  # in meters
 

--- a/projects/bats_2023/analyses/README.md
+++ b/projects/bats_2023/analyses/README.md
@@ -13,8 +13,8 @@ Quick-start example for analyzing transit trips from survey data.
    ```yaml
    - name: link_trips
      params:
-       change_mode_code: 11          # Purpose code for transfers
-       transit_mode_codes: [12, 13, 14]  # Ferry, transit, long distance
+       change_mode_enum: 11          # Purpose code for transfers
+       transit_mode_enums: [12, 13, 14]  # Ferry, transit, long distance
        max_dwell_time: 180           # Max minutes between segments
        dwell_buffer_distance: 100    # Max meters between trip endpoints
    ```
@@ -73,14 +73,14 @@ steps:
 
   - name: link_trips
     params:
-      change_mode_code: 11
-      transit_mode_codes: [12, 13, 14]  # Ferry, transit, long distance
+      change_mode_enum: 11
+      transit_mode_enums: [12, 13, 14]  # Ferry, transit, long distance
       max_dwell_time: 180
       dwell_buffer_distance: 100
 
   - name: summarize_transit_trips
     params:
-      transit_mode_codes: [12, 13]  # Exclude long distance from analysis
+      transit_mode_enums: [12, 13]  # Exclude long distance from analysis
 ```
 
 The `run.py` script loads this config and executes each step using the Pipeline framework.

--- a/projects/bats_2023/analyses/analyze_transit.py
+++ b/projects/bats_2023/analyses/analyze_transit.py
@@ -14,7 +14,7 @@ def summarize_transit_trips(
     unlinked_trips: pl.DataFrame,
     linked_trips: pl.DataFrame,
     trip_weights: pl.DataFrame,
-    transit_mode_codes: list[int],
+    transit_mode_enums: list[int],
 ) -> dict[str, pl.DataFrame]:
     """Summarize transit trips for analysis."""
     county_names = {
@@ -98,7 +98,7 @@ def summarize_transit_trips(
 
     # Calculate transit boardings per linked trip and join back to linked trips
     total_boardings = (
-        unlinked_trips.filter(pl.col("mode_type").is_in(transit_mode_codes))
+        unlinked_trips.filter(pl.col("mode_type").is_in(transit_mode_enums))
         .group_by("linked_trip_id")
         .agg(pl.count("trip_id").alias("boardings"))
     )
@@ -115,7 +115,7 @@ def summarize_transit_trips(
     )
 
     # Filter to transit trips only
-    linked_transit_trips = linked_trips.filter(pl.col("mode_type").is_in(transit_mode_codes))
+    linked_transit_trips = linked_trips.filter(pl.col("mode_type").is_in(transit_mode_enums))
 
     # Summarize total transit trips by origin and destination county
     transit_summary = (

--- a/projects/bats_2023/config.yaml
+++ b/projects/bats_2023/config.yaml
@@ -34,8 +34,8 @@ steps:
     validate_input: false
     cache: true
     params:
-      change_mode_code: 11  # Purpose code for 'change_mode'
-      transit_mode_codes: [12, 13, 14] # NOTE: this is not elegant
+      change_mode_enum: CHANGE_MODE
+      transit_mode_enums: [FERRY, TRANSIT, LONG_DISTANCE]
       max_dwell_time: 180  # in minutes
       dwell_buffer_distance: 100  # in meters
 

--- a/src/processing/link_trips/README.md
+++ b/src/processing/link_trips/README.md
@@ -13,8 +13,8 @@ Links unlinked trip segments into complete journey records by detecting mode cha
 **Inputs:**
 - `unlinked_trips`: Individual trip records (pl.DataFrame)
   - Required columns: person_id, day_id, depart_time, arrive_time, o/d locations, o/d purposes, mode_type
-- `change_mode_code`: Purpose code indicating a mode change (int)
-- `transit_mode_codes`: List of mode codes that count as transit (list[int])
+- `change_mode_enum`: Purpose code indicating a mode change (int)
+- `transit_mode_enums`: List of mode codes that count as transit (list[int])
 - `max_dwell_time`: Maximum time gap between trips to link them, in minutes (default: 120)
 - `dwell_buffer_distance`: Maximum spatial distance between trips to link, in meters (default: 100)
 
@@ -28,7 +28,7 @@ Links unlinked trip segments into complete journey records by detecting mode cha
 **Phase 1: Link Trip IDs**
 1. Sort unlinked trips by person, day, and departure time
 2. For each person-day sequence:
-   - If previous trip's destination purpose is `change_mode_code`, continue the current linked trip
+   - If previous trip's destination purpose is `change_mode_enum`, continue the current linked trip
    - Validate spatial/temporal continuity:
      - Time gap between trips ≤ `max_dwell_time` minutes
      - Distance between previous destination and current origin ≤ `dwell_buffer_distance` meters

--- a/src/processing/link_trips/link.py
+++ b/src/processing/link_trips/link.py
@@ -7,9 +7,8 @@ import polars as pl
 from data_canon.codebook.trips import AccessEgressMode, Driver, ModeType
 from pipeline.decoration import step
 from utils.create_ids import create_linked_trip_id
-from utils.helpers import (
-    expr_haversine,
-)
+from utils.enum_helpers import resolve_enum_labels
+from utils.helpers import expr_haversine
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -38,8 +37,8 @@ MODE_TYPE_TO_ACCESS_EGRESS = {
 @step()
 def link_trips(
     unlinked_trips: pl.DataFrame,
-    change_mode_code: int,
-    transit_mode_codes: list[int],
+    change_mode_enum: str,
+    transit_mode_enums: list[str],
     max_dwell_time: float = 120,
     dwell_buffer_distance: float = 100,
 ) -> dict[str, pl.DataFrame]:
@@ -47,8 +46,8 @@ def link_trips(
 
     Args:
         unlinked_trips: DataFrame containing trip data
-        change_mode_code: Purpose code indicating a mode change
-        transit_mode_codes: List of mode codes that count as transit
+        change_mode_enum: Enum label indicating a mode change
+        transit_mode_enums: List of enum labels that count as transit
         max_dwell_time: Maximum time gap between trips to link them (minutes)
         dwell_buffer_distance: Maximum distance between trips to link (meters)
 
@@ -61,7 +60,7 @@ def link_trips(
     # Link trip IDs
     unlinked_trips_with_ids = link_trip_ids(
         unlinked_trips,
-        change_mode_code,
+        change_mode_enum,
         max_dwell_time,
         dwell_buffer_distance,
     )
@@ -69,7 +68,7 @@ def link_trips(
     # Aggregate linked trips
     linked_trips = aggregate_linked_trips(
         unlinked_trips_with_ids,
-        transit_mode_codes,
+        transit_mode_enums,
     )
 
     logger.info("Trip linking completed.")
@@ -81,7 +80,7 @@ def link_trips(
 
 def link_trip_ids(
     unlinked_trips: pl.DataFrame,
-    change_mode_code: int,
+    change_mode_enum: str,
     max_dwell_time: float = 120,
     dwell_buffer_distance: float = 100,
 ) -> pl.DataFrame:
@@ -98,7 +97,7 @@ def link_trip_ids(
 
     Args:
         unlinked_trips: DataFrame containing trip data
-        change_mode_code: Purpose code indicating a mode change
+        change_mode_enum: Enum label indicating a mode change
         max_dwell_time: Maximum time gap between trips to link them (minutes)
         dwell_buffer_distance: Maximum distance between trips to link (meters)
 
@@ -129,6 +128,11 @@ def link_trip_ids(
         .over("person_id")
         .name.map(lambda c: f"prev_{c}")
     )
+
+    # Get change mode integer code value from enum label
+    change_mode_code = resolve_enum_labels(
+        table_name="unlinked_trips", field_name="d_purpose_category", enum_labels=[change_mode_enum]
+    )[0]
 
     # Step 3: Is new linked trips when:
     #  - prev_purpose not change_mode_code
@@ -181,10 +185,9 @@ def link_trip_ids(
     )
 
 
-# NOTE: Consider removing from this stage and leave to downstream "formatting"
 def aggregate_linked_trips(
     unlinked_trips: pl.DataFrame,
-    transit_mode_codes: list[int],
+    transit_mode_enums: list[str],
 ) -> pl.DataFrame:
     """Aggregate linked trips into single records, summarizing key info.
 
@@ -200,13 +203,17 @@ def aggregate_linked_trips(
 
     Args:
         unlinked_trips: DataFrame with linked_trip_id column
-        transit_mode_codes: List of mode codes that count as transit
+        transit_mode_enums: List of mode enums that count as transit
 
     Returns:
         Aggregated DataFrame with one row per linked trip
 
     """
     logger.info("Aggregating linked trips...")
+
+    transit_mode_codes = resolve_enum_labels(
+        table_name="unlinked_trips", field_name="mode_type", enum_labels=transit_mode_enums
+    )
 
     # First, find the mode type from the longest duration trip segment
     mode_selection = (

--- a/src/utils/enum_helpers.py
+++ b/src/utils/enum_helpers.py
@@ -1,0 +1,161 @@
+"""Helper functions for resolving enum labels to values.
+
+This module provides utilities for working with codebook enumerations,
+particularly for resolving enum member names to their numeric values
+and preparing data for imputation by replacing sentinel/missing values.
+"""
+
+import inspect
+import logging
+from typing import get_args, get_origin
+
+from data_canon.core.labeled_enum import LabeledEnum
+from data_canon.models.survey import (
+    HouseholdModel,
+    JointTripModel,
+    LinkedTripModel,
+    PersonModel,
+    TourModel,
+    UnlinkedTripModel,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# Map table names to their Pydantic model classes (canonical survey models only)
+MODEL_MAPPING = {
+    "households": HouseholdModel,
+    "persons": PersonModel,
+    "unlinked_trips": UnlinkedTripModel,
+    "linked_trips": LinkedTripModel,
+    "tours": TourModel,
+    "joint_trips": JointTripModel,
+}
+
+
+def _extract_enum_from_annotation(annotation: object) -> type[LabeledEnum] | None:
+    """Extract the enum class from a field's type annotation.
+
+    Handles both direct enum types and Union types (e.g., IncomeBroad | None).
+
+    Args:
+        annotation: The field's type annotation
+
+    Returns:
+        The enum class if found and is a LabeledEnum, None otherwise
+
+    Example:
+        >>> _extract_enum_from_annotation(IncomeBroad | None)
+        <enum 'IncomeBroad'>
+        >>> _extract_enum_from_annotation(str)
+        None
+    """
+    # Handle Union types (e.g., IncomeBroad | None or Optional[IncomeBroad])
+    origin = get_origin(annotation)
+    if origin is not None:  # This is a generic type like Union
+        args = get_args(annotation)
+        # Filter out None and find the first LabeledEnum
+        for arg in args:
+            if arg is type(None):
+                continue
+            if inspect.isclass(arg) and issubclass(arg, LabeledEnum):
+                return arg
+        return None
+
+    # Direct type (not Union)
+    if inspect.isclass(annotation) and issubclass(annotation, LabeledEnum):
+        return annotation
+
+    return None
+
+
+def get_enum_class_for_field(table_name: str, field_name: str) -> type[LabeledEnum] | None:
+    """Find the enum class for a given field in a table.
+
+    Uses the Pydantic model's type annotations to determine the enum class
+    for a field. For example, if HouseholdModel has `income_bin: IncomeBroad`,
+    this function will return the IncomeBroad enum class.
+
+    Args:
+        table_name: Name of the table (e.g., 'households', 'persons', 'unlinked_trips')
+        field_name: Name of the field/column to find enum for
+
+    Returns:
+        The enum class if found, None otherwise
+
+    Example:
+        >>> enum_class = get_enum_class_for_field('households', 'income_bin')
+        >>> enum_class
+        <enum 'IncomeBroad'>
+    """
+    # Get the model class for this table
+    model_class = MODEL_MAPPING.get(table_name)
+    if not model_class:
+        msg = "Unknown table name '%s' - cannot find model class"
+        raise ValueError(msg % table_name)
+
+    # Get the field info from the model
+    if field_name not in model_class.model_fields:
+        msg = "Field '%s' not found in model for table '%s'"
+        raise ValueError(msg % (field_name, table_name))
+
+    field_info = model_class.model_fields[field_name]
+    enum_class = _extract_enum_from_annotation(field_info.annotation)
+
+    if not enum_class:
+        msg = "No enum class found for field '%s' in table '%s'"
+        raise ValueError(msg % (field_name, table_name))
+
+    return enum_class
+
+
+def resolve_enum_labels(
+    table_name: str, field_name: str, enum_labels: list[str | int]
+) -> list[int | str]:
+    """Resolve enum labels to their values for a given field.
+
+    Args:
+        table_name: Name of the table containing the field
+        field_name: Name of the field/column
+        enum_labels: List of enum member names (e.g., ['MISSING', 'PNTA'])
+
+    Returns:
+        List of resolved values (integers or strings)
+
+    Example:
+        >>> resolve_enum_labels('households', 'income_bin', ['MISSING', 'PNTA'])
+        [995, 999]
+    """
+    # If it is already an integer, we're going to throw a shameful warning but pass it along
+    if all(
+        isinstance(label, int) or (isinstance(label, str) and label.isdigit())
+        for label in enum_labels
+    ):
+        logger.warning(
+            """
+            Looks like you passed in integer values directly, tsk tsk.
+            This is not recommended but we'll pass it through as integers and hope for the best.
+            """
+        )
+        return [int(label) for label in enum_labels]
+
+    enum_class = get_enum_class_for_field(table_name, field_name)
+    if not enum_class:
+        msg = (
+            f"Cannot resolve enum labels for field '{field_name}' "
+            f"in table '{table_name}' - no enum class found"
+        )
+        raise ValueError(msg)
+
+    resolved_values = []
+    for label in enum_labels:
+        try:
+            resolved_values.append(enum_class[str(label)].value)
+        except KeyError as err:
+            msg = (
+                f"Label '{label}' not found in enum '{enum_class.__name__}' "
+                f"for field '{field_name}'"
+            )
+            raise ValueError(msg) from err
+
+    return resolved_values

--- a/tests/fixtures/fixtures.py
+++ b/tests/fixtures/fixtures.py
@@ -276,8 +276,8 @@ def process_scenario_through_pipeline(
     # Link trips (using config.yaml defaults)
     link_result = link_trips(
         unlinked_trips,
-        change_mode_code=PurposeCategory.CHANGE_MODE.value,
-        transit_mode_codes=DEFAULT_TRANSIT_MODE_CODES,
+        change_mode_enum=PurposeCategory.CHANGE_MODE.value,
+        transit_mode_enums=DEFAULT_TRANSIT_MODE_CODES,
         max_dwell_time=180,  # in minutes
         dwell_buffer_distance=100,  # in meters
     )

--- a/tests/test_daysim_formatter.py
+++ b/tests/test_daysim_formatter.py
@@ -865,8 +865,8 @@ class TestTripFormatting:
         # Run through link_trips pipeline
         result_dict = link_trips(
             unlinked_trips,
-            change_mode_code=PurposeCategory.CHANGE_MODE.value,
-            transit_mode_codes=[Mode.BART.value, Mode.BUS_LOCAL.value],
+            change_mode_enum=PurposeCategory.CHANGE_MODE.value,
+            transit_mode_enums=[Mode.BART.value, Mode.BUS_LOCAL.value],
         )
 
         unlinked_trips_with_ids = result_dict["unlinked_trips"]
@@ -919,8 +919,8 @@ class TestTripFormatting:
 
         result_dict = link_trips(
             unlinked_trips,
-            change_mode_code=PurposeCategory.CHANGE_MODE.value,
-            transit_mode_codes=[Mode.BART.value, Mode.BUS_LOCAL.value],
+            change_mode_enum=PurposeCategory.CHANGE_MODE.value,
+            transit_mode_enums=[Mode.BART.value, Mode.BUS_LOCAL.value],
         )
 
         unlinked_trips_with_ids = result_dict["unlinked_trips"]
@@ -974,8 +974,8 @@ class TestTripFormatting:
 
         result_dict = link_trips(
             unlinked_trips,
-            change_mode_code=PurposeCategory.CHANGE_MODE.value,
-            transit_mode_codes=[Mode.BART.value, Mode.BUS_LOCAL.value],
+            change_mode_enum=PurposeCategory.CHANGE_MODE.value,
+            transit_mode_enums=[Mode.BART.value, Mode.BUS_LOCAL.value],
         )
 
         unlinked_trips_with_ids = result_dict["unlinked_trips"]
@@ -1029,8 +1029,8 @@ class TestTripFormatting:
 
         result_dict = link_trips(
             unlinked_trips,
-            change_mode_code=PurposeCategory.CHANGE_MODE.value,
-            transit_mode_codes=[Mode.BART.value, Mode.BUS_LOCAL.value],
+            change_mode_enum=PurposeCategory.CHANGE_MODE.value,
+            transit_mode_enums=[Mode.BART.value, Mode.BUS_LOCAL.value],
         )
 
         unlinked_trips_with_ids = result_dict["unlinked_trips"]
@@ -1085,8 +1085,8 @@ class TestTripFormatting:
 
         result_dict = link_trips(
             unlinked_trips,
-            change_mode_code=PurposeCategory.CHANGE_MODE.value,
-            transit_mode_codes=[Mode.BART.value, Mode.BUS_LOCAL.value],
+            change_mode_enum=PurposeCategory.CHANGE_MODE.value,
+            transit_mode_enums=[Mode.BART.value, Mode.BUS_LOCAL.value],
         )
 
         unlinked_trips_with_ids = result_dict["unlinked_trips"]
@@ -1136,8 +1136,8 @@ class TestTripFormatting:
 
         result_dict = link_trips(
             unlinked_trips,
-            change_mode_code=PurposeCategory.CHANGE_MODE.value,
-            transit_mode_codes=[Mode.BART.value, Mode.BUS_LOCAL.value],
+            change_mode_enum=PurposeCategory.CHANGE_MODE.value,
+            transit_mode_enums=[Mode.BART.value, Mode.BUS_LOCAL.value],
         )
 
         unlinked_trips_with_ids = result_dict["unlinked_trips"]
@@ -1190,8 +1190,8 @@ class TestTripFormatting:
 
         result_dict = link_trips(
             unlinked_trips,
-            change_mode_code=PurposeCategory.CHANGE_MODE.value,
-            transit_mode_codes=[Mode.BART.value, Mode.BUS_LOCAL.value],
+            change_mode_enum=PurposeCategory.CHANGE_MODE.value,
+            transit_mode_enums=[Mode.BART.value, Mode.BUS_LOCAL.value],
         )
 
         unlinked_trips_with_ids = result_dict["unlinked_trips"]
@@ -1395,8 +1395,8 @@ class TestEndToEndDaysimFormatting:
 
         linked_result = link_trips(
             unlinked_trips_fixture,
-            change_mode_code=PurposeCategory.CHANGE_MODE.value,
-            transit_mode_codes=[Mode.BART.value],
+            change_mode_enum=PurposeCategory.CHANGE_MODE.value,
+            transit_mode_enums=[Mode.BART.value],
         )
 
         # Add joint_trip_id for extract_tours validation

--- a/tests/test_duration_tiebreaker.py
+++ b/tests/test_duration_tiebreaker.py
@@ -63,8 +63,8 @@ def create_test_data(
 
     unlinked_trips, linked_trips = link_trips(
         unlinked_trips,
-        change_mode_code=11,  # Purpose code for 'change_mode'
-        transit_mode_codes=[12, 13, 14],
+        change_mode_enum=11,  # Purpose code for 'change_mode'
+        transit_mode_enums=[12, 13, 14],
         max_dwell_time=180,  # in minutes
         dwell_buffer_distance=100,  # in meters
     ).values()

--- a/tests/test_enum_helpers.py
+++ b/tests/test_enum_helpers.py
@@ -1,0 +1,72 @@
+"""Test enum helpers utility."""
+
+import pytest
+
+from data_canon.codebook.households import ResidenceRentOwn
+from data_canon.codebook.persons import Gender
+from utils.enum_helpers import (
+    get_enum_class_for_field,
+    resolve_enum_labels,
+)
+
+
+class TestGetEnumClassForField:
+    """Tests for discovering the enum class attached to a model field."""
+
+    def test_direct_enum_field(self):
+        """Enum field without Optional wrapper returns the enum class."""
+        enum_class = get_enum_class_for_field("persons", "gender")
+        assert enum_class is Gender
+
+    def test_optional_enum_field(self):
+        """Optional[Enum] field still returns the underlying enum class."""
+        # residence_rent_own is a direct enum field on HouseholdModel
+        enum_class = get_enum_class_for_field("households", "residence_rent_own")
+        assert enum_class is ResidenceRentOwn
+
+    def test_non_enum_field_raises(self):
+        """Non-enum fields (e.g., float, int) raise ValueError."""
+        with pytest.raises(ValueError, match="No enum class found"):
+            get_enum_class_for_field("households", "home_lat")
+
+    def test_unknown_table_raises(self):
+        """Unknown table names raise ValueError."""
+        with pytest.raises(ValueError, match="Unknown table name"):
+            get_enum_class_for_field("nonexistent_table", "some_field")
+
+    def test_unknown_field_raises(self):
+        """Unknown field names raise ValueError."""
+        with pytest.raises(ValueError, match="not found in model"):
+            get_enum_class_for_field("persons", "nonexistent_field")
+
+
+class TestResolveEnumLabels:
+    """Tests for resolving enum member names to their integer values."""
+
+    def test_resolve_single_label(self):
+        """Resolving a single enum label returns its value."""
+        values = resolve_enum_labels("persons", "gender", ["FEMALE"])
+        assert values == [Gender.FEMALE.value]
+
+    def test_resolve_multiple_labels(self):
+        """Resolving multiple labels returns all values in order."""
+        values = resolve_enum_labels("persons", "gender", ["MISSING", "PNTA"])
+        assert values == [995, 999]
+
+    def test_resolve_household_enum(self):
+        """Resolving works across different table/model types."""
+        values = resolve_enum_labels("households", "residence_rent_own", ["OWN", "RENT"])
+        assert values == [
+            ResidenceRentOwn.OWN.value,
+            ResidenceRentOwn.RENT.value,
+        ]
+
+    def test_bad_label_raises(self):
+        """An invalid enum label raises ValueError."""
+        with pytest.raises(ValueError, match="not found in enum"):
+            resolve_enum_labels("persons", "gender", ["INVALID_LABEL"])
+
+    def test_no_enum_raises(self):
+        """Resolving labels for a non-enum field raises ValueError."""
+        with pytest.raises(ValueError, match="No enum class found"):
+            resolve_enum_labels("households", "home_lat", ["SOMETHING"])

--- a/tests/test_joint_tours.py
+++ b/tests/test_joint_tours.py
@@ -83,8 +83,8 @@ def link_and_detect_joint_trips(
     # Link trips first
     link_result = link_trips(
         unlinked_trips=unlinked_trips,
-        change_mode_code=PurposeCategory.CHANGE_MODE.value,
-        transit_mode_codes=[ModeType.TRANSIT.value],
+        change_mode_enum=PurposeCategory.CHANGE_MODE.value,
+        transit_mode_enums=[ModeType.TRANSIT.value],
     )
     unlinked_trips_with_ids = link_result["unlinked_trips"]
     linked_trips = link_result["linked_trips"]

--- a/tests/test_legacy_link_trips.py
+++ b/tests/test_legacy_link_trips.py
@@ -270,8 +270,8 @@ def test_linking_row_count():
     legacy_result, _ = link_trip_legacy(legacy_data, act_dur_limit=35, act_dur_limit2=15)
     new_result = link_trips(
         new_data,
-        change_mode_code=PURPOSE_MAP_NEW["change_mode"],
-        transit_mode_codes=[MODE_MAP["transit"]],
+        change_mode_enum=PURPOSE_MAP_NEW["change_mode"],
+        transit_mode_enums=[MODE_MAP["transit"]],
         max_dwell_time=120,
         dwell_buffer_distance=100,
     )
@@ -296,8 +296,8 @@ def test_linked_trip_purposes():
     # Run new implementation
     new_result = link_trips(
         new_data,
-        change_mode_code=PURPOSE_MAP_NEW["change_mode"],
-        transit_mode_codes=[MODE_MAP["transit"]],
+        change_mode_enum=PURPOSE_MAP_NEW["change_mode"],
+        transit_mode_enums=[MODE_MAP["transit"]],
         max_dwell_time=120,
         dwell_buffer_distance=100,
     )
@@ -330,8 +330,8 @@ def test_linked_trip_modes():
     legacy_result, _ = link_trip_legacy(legacy_data, act_dur_limit=35, act_dur_limit2=15)
     new_result = link_trips(
         new_data,
-        change_mode_code=PURPOSE_MAP_NEW["change_mode"],
-        transit_mode_codes=[MODE_MAP["transit"]],
+        change_mode_enum=PURPOSE_MAP_NEW["change_mode"],
+        transit_mode_enums=[MODE_MAP["transit"]],
         max_dwell_time=120,
         dwell_buffer_distance=100,
     )

--- a/tests/test_legacy_tours.py
+++ b/tests/test_legacy_tours.py
@@ -247,8 +247,8 @@ def simple_work_tour_data():
     # Link trips for legacy format
     result = link_trips(
         unlinked_trips,
-        change_mode_code=PurposeCategory.CHANGE_MODE.value,
-        transit_mode_codes=[ModeType.TRANSIT.value, ModeType.FERRY.value],
+        change_mode_enum=PurposeCategory.CHANGE_MODE.value,
+        transit_mode_enums=[ModeType.TRANSIT.value, ModeType.FERRY.value],
     )
     unlinked_trips_with_ids = result["unlinked_trips"]
     # Sort because legacy code expects trips in depart_time order
@@ -284,8 +284,8 @@ def work_tour_with_subtour_data():
     # Link trips for legacy format
     result = link_trips(
         unlinked_trips,
-        change_mode_code=PurposeCategory.CHANGE_MODE.value,
-        transit_mode_codes=[ModeType.TRANSIT.value, ModeType.FERRY.value],
+        change_mode_enum=PurposeCategory.CHANGE_MODE.value,
+        transit_mode_enums=[ModeType.TRANSIT.value, ModeType.FERRY.value],
     )
     unlinked_trips_with_ids = result["unlinked_trips"]
     # Sort because legacy code expects trips in depart_time order
@@ -323,8 +323,8 @@ def multiple_tours_data():
     # Link trips for legacy format
     result = link_trips(
         unlinked_trips,
-        change_mode_code=PurposeCategory.CHANGE_MODE.value,
-        transit_mode_codes=[ModeType.TRANSIT.value, ModeType.FERRY.value],
+        change_mode_enum=PurposeCategory.CHANGE_MODE.value,
+        transit_mode_enums=[ModeType.TRANSIT.value, ModeType.FERRY.value],
     )
     unlinked_trips_with_ids = result["unlinked_trips"]
     # Sort because legacy code expects trips in depart_time order
@@ -811,8 +811,8 @@ def test_tour_timing():
     # Link trips first
     link_result = link_trips(
         unlinked_trips=trips,
-        change_mode_code=PurposeCategory.CHANGE_MODE.value,
-        transit_mode_codes=TRANSIT_MODE_CODES,
+        change_mode_enum=PurposeCategory.CHANGE_MODE.value,
+        transit_mode_enums=TRANSIT_MODE_CODES,
     )
     unlinked_trips_with_ids = link_result["unlinked_trips"]
     linked_trips = link_result["linked_trips"].with_columns(
@@ -969,8 +969,8 @@ def test_tour_trip_counts():
     # Link trips first
     link_result = link_trips(
         unlinked_trips=trips,
-        change_mode_code=PurposeCategory.CHANGE_MODE.value,
-        transit_mode_codes=TRANSIT_MODE_CODES,
+        change_mode_enum=PurposeCategory.CHANGE_MODE.value,
+        transit_mode_enums=TRANSIT_MODE_CODES,
     )
     unlinked_trips_with_ids = link_result["unlinked_trips"]
     linked_trips = link_result["linked_trips"].with_columns(
@@ -1093,8 +1093,8 @@ def test_incomplete_tour_at_end_of_day():
     # Link trips first
     link_result = link_trips(
         unlinked_trips=trips,
-        change_mode_code=PurposeCategory.CHANGE_MODE.value,
-        transit_mode_codes=TRANSIT_MODE_CODES,
+        change_mode_enum=PurposeCategory.CHANGE_MODE.value,
+        transit_mode_enums=TRANSIT_MODE_CODES,
     )
     unlinked_trips_with_ids = link_result["unlinked_trips"]
     linked_trips = link_result["linked_trips"].with_columns(
@@ -1201,8 +1201,8 @@ def test_no_work_location():
     # Link trips first
     link_result = link_trips(
         unlinked_trips=trips,
-        change_mode_code=PurposeCategory.CHANGE_MODE.value,
-        transit_mode_codes=TRANSIT_MODE_CODES,
+        change_mode_enum=PurposeCategory.CHANGE_MODE.value,
+        transit_mode_enums=TRANSIT_MODE_CODES,
     )
     unlinked_trips_with_ids = link_result["unlinked_trips"]
     linked_trips = link_result["linked_trips"].with_columns(

--- a/tests/test_link_trips.py
+++ b/tests/test_link_trips.py
@@ -49,7 +49,7 @@ class TestLinkTripIds:
 
         result = link_trip_ids(
             trips,
-            change_mode_code=10,
+            change_mode_enum=10,
             max_dwell_time=120,
             dwell_buffer_distance=100,
         )
@@ -90,7 +90,7 @@ class TestLinkTripIds:
 
         result = link_trip_ids(
             trips,
-            change_mode_code=10,
+            change_mode_enum=10,
             max_dwell_time=120,
             dwell_buffer_distance=100,
         )
@@ -127,7 +127,7 @@ class TestLinkTripIds:
 
         result = link_trip_ids(
             trips,
-            change_mode_code=10,
+            change_mode_enum=10,
             max_dwell_time=120,
             dwell_buffer_distance=100,
         )
@@ -164,7 +164,7 @@ class TestLinkTripIds:
 
         result = link_trip_ids(
             trips,
-            change_mode_code=10,
+            change_mode_enum=10,
             max_dwell_time=120,  # 120 minutes
             dwell_buffer_distance=100,
         )
@@ -201,7 +201,7 @@ class TestLinkTripIds:
 
         result = link_trip_ids(
             trips,
-            change_mode_code=10,
+            change_mode_enum=10,
             max_dwell_time=120,
             dwell_buffer_distance=10,  # 10 miles
         )
@@ -249,7 +249,7 @@ class TestLinkTripIds:
 
         result = link_trip_ids(
             trips,
-            change_mode_code=10,
+            change_mode_enum=10,
             max_dwell_time=120,
             dwell_buffer_distance=100,
         )
@@ -298,7 +298,7 @@ class TestLinkTripIds:
 
         result = link_trip_ids(
             trips,
-            change_mode_code=10,
+            change_mode_enum=10,
             max_dwell_time=120,
             dwell_buffer_distance=100,
         )
@@ -335,7 +335,7 @@ class TestLinkTripIds:
 
         result = link_trip_ids(
             trips,
-            change_mode_code=10,
+            change_mode_enum=10,
             max_dwell_time=120,
             dwell_buffer_distance=100,
         )
@@ -363,7 +363,7 @@ class TestLinkTripIds:
 
         result = link_trip_ids(
             trips,
-            change_mode_code=10,
+            change_mode_enum=10,
             max_dwell_time=120,
             dwell_buffer_distance=100,
         )
@@ -424,7 +424,7 @@ class TestAggregateLinkedTrips:
             }
         )
 
-        result = aggregate_linked_trips(trips, transit_mode_codes=[ModeType.TRANSIT.value])
+        result = aggregate_linked_trips(trips, transit_mode_enums=[ModeType.TRANSIT.value])
 
         # Should have one aggregated trip
         assert len(result) == 1
@@ -505,7 +505,7 @@ class TestAggregateLinkedTrips:
             }
         )
 
-        result = aggregate_linked_trips(trips, transit_mode_codes=[ModeType.TRANSIT.value])
+        result = aggregate_linked_trips(trips, transit_mode_enums=[ModeType.TRANSIT.value])
 
         # Should select transit mode
         assert result["mode_type"][0] == ModeType.TRANSIT.value
@@ -559,7 +559,7 @@ class TestAggregateLinkedTrips:
             }
         )
 
-        result = aggregate_linked_trips(trips, transit_mode_codes=[ModeType.TRANSIT.value])
+        result = aggregate_linked_trips(trips, transit_mode_enums=[ModeType.TRANSIT.value])
 
         # Should select drive (mode 3) as longest duration
         assert result["mode_type"][0] == ModeType.CAR.value
@@ -610,7 +610,7 @@ class TestAggregateLinkedTrips:
             }
         )
 
-        result = aggregate_linked_trips(trips, transit_mode_codes=[ModeType.TRANSIT.value])
+        result = aggregate_linked_trips(trips, transit_mode_enums=[ModeType.TRANSIT.value])
 
         row = result.row(0, named=True)
         # Total duration: 8:00 to 8:45 = 45 min
@@ -682,7 +682,7 @@ class TestAggregateLinkedTrips:
             }
         )
 
-        result = aggregate_linked_trips(trips, transit_mode_codes=[ModeType.TRANSIT.value])
+        result = aggregate_linked_trips(trips, transit_mode_enums=[ModeType.TRANSIT.value])
 
         # Should have two aggregated trips
         assert len(result) == 2
@@ -759,8 +759,8 @@ class TestLinkTripsIntegration:
 
         result = link_trips(
             trips,
-            change_mode_code=PurposeCategory.CHANGE_MODE.value,
-            transit_mode_codes=[ModeType.TRANSIT.value],
+            change_mode_enum=PurposeCategory.CHANGE_MODE.value,
+            transit_mode_enums=[ModeType.TRANSIT.value],
             max_dwell_time=120,
             dwell_buffer_distance=100,
         )
@@ -816,8 +816,8 @@ class TestLinkTripsIntegration:
 
         result = link_trips(
             trips,
-            change_mode_code=10,
-            transit_mode_codes=[ModeType.TRANSIT.value],
+            change_mode_enum=10,
+            transit_mode_enums=[ModeType.TRANSIT.value],
             max_dwell_time=120,
         )
 
@@ -1010,7 +1010,7 @@ class TestTableLevelUniqueness:
 
         # Aggregate into linked trips table
         linked_trips = aggregate_linked_trips(
-            unlinked_trips, transit_mode_codes=[ModeType.TRANSIT.value]
+            unlinked_trips, transit_mode_enums=[ModeType.TRANSIT.value]
         )
 
         # CRITICAL: linked_trips table MUST have unique linked_trip_ids
@@ -1100,7 +1100,7 @@ class TestTableLevelUniqueness:
         )
 
         linked_trips = aggregate_linked_trips(
-            unlinked_trips, transit_mode_codes=[ModeType.TRANSIT.value]
+            unlinked_trips, transit_mode_enums=[ModeType.TRANSIT.value]
         )
 
         # 4 unlinked segments become 2 linked trips
@@ -1203,8 +1203,8 @@ class TestTableLevelUniqueness:
 
         result = link_trips(
             trips,
-            change_mode_code=PurposeCategory.CHANGE_MODE.value,
-            transit_mode_codes=[ModeType.TRANSIT.value],
+            change_mode_enum=PurposeCategory.CHANGE_MODE.value,
+            transit_mode_enums=[ModeType.TRANSIT.value],
             max_dwell_time=120,
         )
 

--- a/tests/test_tour_edge_cases.py
+++ b/tests/test_tour_edge_cases.py
@@ -84,8 +84,8 @@ def single_trip_tour_data():
     # Link trips
     link_result = link_trips(
         unlinked_trips=unlinked_trips,
-        change_mode_code=PurposeCategory.CHANGE_MODE.value,
-        transit_mode_codes=[ModeType.TRANSIT.value],
+        change_mode_enum=PurposeCategory.CHANGE_MODE.value,
+        transit_mode_enums=[ModeType.TRANSIT.value],
     )
     unlinked_trips_with_ids = link_result["unlinked_trips"]
     linked_trips = link_result["linked_trips"].with_columns(
@@ -188,8 +188,8 @@ def partial_tour_data():
     # Link trips
     link_result = link_trips(
         unlinked_trips=unlinked_trips,
-        change_mode_code=PurposeCategory.CHANGE_MODE.value,
-        transit_mode_codes=[ModeType.TRANSIT.value],
+        change_mode_enum=PurposeCategory.CHANGE_MODE.value,
+        transit_mode_enums=[ModeType.TRANSIT.value],
     )
     unlinked_trips_with_ids = link_result["unlinked_trips"]
     linked_trips = link_result["linked_trips"].with_columns(
@@ -292,8 +292,8 @@ def distant_destinations_data():
     # Link trips
     link_result = link_trips(
         unlinked_trips=unlinked_trips,
-        change_mode_code=PurposeCategory.CHANGE_MODE.value,
-        transit_mode_codes=[ModeType.TRANSIT.value],
+        change_mode_enum=PurposeCategory.CHANGE_MODE.value,
+        transit_mode_enums=[ModeType.TRANSIT.value],
     )
     unlinked_trips_with_ids = link_result["unlinked_trips"]
     linked_trips = link_result["linked_trips"].with_columns(
@@ -449,8 +449,8 @@ def test_tour_num_sequential():
     # Link trips first
     link_result = link_trips(
         unlinked_trips=unlinked_trips,
-        change_mode_code=PurposeCategory.CHANGE_MODE.value,
-        transit_mode_codes=[ModeType.TRANSIT.value],
+        change_mode_enum=PurposeCategory.CHANGE_MODE.value,
+        transit_mode_enums=[ModeType.TRANSIT.value],
     )
     unlinked_trips_with_ids = link_result["unlinked_trips"]
     linked_trips = link_result["linked_trips"].with_columns(
@@ -566,8 +566,8 @@ def test_all_tours_have_required_fields():
     # Link trips first
     link_result = link_trips(
         unlinked_trips=unlinked_trips,
-        change_mode_code=PurposeCategory.CHANGE_MODE.value,
-        transit_mode_codes=[ModeType.TRANSIT.value],
+        change_mode_enum=PurposeCategory.CHANGE_MODE.value,
+        transit_mode_enums=[ModeType.TRANSIT.value],
     )
     unlinked_trips_with_ids = link_result["unlinked_trips"]
     linked_trips = link_result["linked_trips"].with_columns(


### PR DESCRIPTION
## Description
The long awaited ENUM helper for passing human readable enums into the config instead of integers!

Robo summary 🤖
This pull request refactors the way mode and purpose codes are handled throughout the trip-linking pipeline, shifting from using integer codes to using enum labels for greater clarity and maintainability. It introduces a new utility, `resolve_enum_labels`, to convert enum labels to their corresponding code values, and updates function signatures, documentation, and configuration files to use enum labels instead of raw integer codes. This change improves code readability and reduces the risk of errors related to mismatched or unclear code values.

Key changes include:

**Core pipeline and utilities:**

* Introduced `src/utils/enum_helpers.py` with the `resolve_enum_labels` function, which maps enum labels to their corresponding values using Pydantic model metadata. This utility is now used throughout the trip-linking process.
* Refactored the `link_trips`, `link_trip_ids`, and `aggregate_linked_trips` functions in `src/processing/link_trips/link.py` to accept and process enum labels (`change_mode_enum`, `transit_mode_enums`) instead of integer codes, resolving them to code values internally. Updated all related docstrings and argument names accordingly. [[1]](diffhunk://#diff-65dd0f3c557ff1ed1781a0991838f8097a837942d784cced1a00de39bede22e6L10-R11) [[2]](diffhunk://#diff-65dd0f3c557ff1ed1781a0991838f8097a837942d784cced1a00de39bede22e6L41-R50) [[3]](diffhunk://#diff-65dd0f3c557ff1ed1781a0991838f8097a837942d784cced1a00de39bede22e6L64-R71) [[4]](diffhunk://#diff-65dd0f3c557ff1ed1781a0991838f8097a837942d784cced1a00de39bede22e6L84-R83) [[5]](diffhunk://#diff-65dd0f3c557ff1ed1781a0991838f8097a837942d784cced1a00de39bede22e6L101-R100) [[6]](diffhunk://#diff-65dd0f3c557ff1ed1781a0991838f8097a837942d784cced1a00de39bede22e6R132-R136) [[7]](diffhunk://#diff-65dd0f3c557ff1ed1781a0991838f8097a837942d784cced1a00de39bede22e6L184-R190) [[8]](diffhunk://#diff-65dd0f3c557ff1ed1781a0991838f8097a837942d784cced1a00de39bede22e6L203-R217)

**Configuration and documentation:**

* Updated YAML config files (`projects/bats_2019/config.yaml`, `projects/bats_2023/config.yaml`, and `README.md` files) to use enum labels (e.g., `CHANGE_MODE`, `FERRY`, `TRANSIT`, `LONG_DISTANCE`) instead of integer codes for trip linking parameters. [[1]](diffhunk://#diff-96e77b3be9045d97455082b8ca3839313d63898f94aac1e194aa2b0a53f6c6baL40-R41) [[2]](diffhunk://#diff-89f6105303b141dea9f79a0e30ea6a77017313478d85ff80a154d472f5c903baL37-R38) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L264-R265) [[4]](diffhunk://#diff-8fea403fb66228520064d37dc5f819a1cd0cc02c10a81eb008a543d2b04e6137L16-R17) [[5]](diffhunk://#diff-8fea403fb66228520064d37dc5f819a1cd0cc02c10a81eb008a543d2b04e6137L76-R83)
* Revised documentation in `src/processing/link_trips/README.md` and analysis scripts to reflect the new enum-based parameter names and usage. [[1]](diffhunk://#diff-1ef254d6d18dfb418e6792c6ad81f46591006d2b687c2f9611290d4fa6296be2L16-R17) [[2]](diffhunk://#diff-1ef254d6d18dfb418e6792c6ad81f46591006d2b687c2f9611290d4fa6296be2L31-R31) [[3]](diffhunk://#diff-bad15f0a00e228bc3d99da40d9edafee83e5ebefd0721c082ff926de9e7f14dcL17-R17) [[4]](diffhunk://#diff-bad15f0a00e228bc3d99da40d9edafee83e5ebefd0721c082ff926de9e7f14dcL101-R101) [[5]](diffhunk://#diff-bad15f0a00e228bc3d99da40d9edafee83e5ebefd0721c082ff926de9e7f14dcL118-R118)

**Tests and fixtures:**

* Updated all test cases and fixtures to use the new `change_mode_enum` and `transit_mode_enums` parameters, passing enum labels or values as appropriate. [[1]](diffhunk://#diff-9b51bddca1ee6939e679688418a5d0a0ff1e66cf6df7b10df1d015d1134972c0L279-R280) [[2]](diffhunk://#diff-2e58d0ec57d3cb82485291151807e184979f9c93a5f9c6d0f5aa348f230a0f73L868-R869) [[3]](diffhunk://#diff-2e58d0ec57d3cb82485291151807e184979f9c93a5f9c6d0f5aa348f230a0f73L922-R923) [[4]](diffhunk://#diff-2e58d0ec57d3cb82485291151807e184979f9c93a5f9c6d0f5aa348f230a0f73L977-R978) [[5]](diffhunk://#diff-2e58d0ec57d3cb82485291151807e184979f9c93a5f9c6d0f5aa348f230a0f73L1032-R1033) [[6]](diffhunk://#diff-2e58d0ec57d3cb82485291151807e184979f9c93a5f9c6d0f5aa348f230a0f73L1088-R1089)

These changes collectively make the codebase more robust, easier to understand, and less error-prone by standardizing on enum labels for all mode and purpose code references.

## Type of Change
<!-- Check all that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass
- [x] Added new tests to cover changes
- [x] Manually tested the changes

## Checklist
<!-- Check all that apply -->
- [x] My code follows the style guidelines of this project (runs `ruff check .` without errors)
- [x] My code is properly formatted (runs `ruff format .`)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published