### PR TITLE
Corrected data model, applied fixes

### DIFF
--- a/projects/bats_2023/config.yaml
+++ b/projects/bats_2023/config.yaml
@@ -128,6 +128,7 @@ steps:
   # This prepares a new set of files formatted for DaySim
   - name: format_daysim
     validate_input: false
+    validate_output: true
     cache: false
     params:
       drop_partial_tours: true

--- a/src/data_canon/models/daysim.py
+++ b/src/data_canon/models/daysim.py
@@ -76,12 +76,12 @@ class HouseholdDaysimModel(BaseModel):
     hhxco: float = Field(ge=-9999, le=9999, description="Household residence X coordinate")
     hhyco: float = Field(ge=-9999, le=9999, description="Household residence Y coordinate")
     hhparcel: int = Field(
-        ge=1,
+        ge=-1,
         le=9999999,
         description="The ID of the parcel on which the household lives",
     )
     hhtaz: int = Field(
-        ge=1,
+        ge=-1,
         le=9999999,
         description="The ID of the zone in which the household lives",
     )
@@ -130,10 +130,6 @@ class PersonDaysimModel(BaseModel):
     ppaidprk: int = Field(ge=-1, le=1, description="Worker has to pay to park at work")
     pdiary: int = Field(ge=0, le=1, description="Survey respondent used their diary")
     pproxy: int = Field(ge=0, le=1, description="Survey responses by proxy")
-    psxco: float | None = Field(ge=-9999, le=9999, description="Person's school X coordinate")
-    psyco: float | None = Field(ge=-9999, le=9999, description="Person's school Y coordinate")
-    pwxco: float | None = Field(ge=-9999, le=9999, description="Person's work X coordinate")
-    pwyco: float | None = Field(ge=-9999, le=9999, description="Person's work Y coordinate")
     psexpfac: float = Field(ge=0, description="The expansion factor for the person")
 
 
@@ -267,17 +263,17 @@ class PersonDayDaysimModel(BaseModel):
         le=1439,
         description="The number of minutes spent working at home during the day",
     )
-    pwxco: float | None = Field(
-        ge=-9999, le=9999, description="Person's work location X coordinate"
+    pwxco: float = Field(
+        default=0.0, ge=-9999, le=9999, description="Person's work location X coordinate"
     )
-    pwyco: float | None = Field(
-        ge=-9999, le=9999, description="Person's work location Y coordinate"
+    pwyco: float = Field(
+        default=0.0, ge=-9999, le=9999, description="Person's work location Y coordinate"
     )
-    psxco: float | None = Field(
-        ge=-9999, le=9999, description="Person's school location X coordinate"
+    psxco: float = Field(
+        default=0.0, ge=-9999, le=9999, description="Person's school location X coordinate"
     )
-    psyco: float | None = Field(
-        ge=-9999, le=9999, description="Person's school location Y coordinate"
+    psyco: float = Field(
+        default=0.0, ge=-9999, le=9999, description="Person's school location Y coordinate"
     )
     pdexpfac: float = Field(ge=0, description="The expansion factor for the person-day")
 
@@ -391,12 +387,12 @@ class LinkedTripDaysimModel(BaseModel):
     dpurp: DaysimPurpose = Field(description="The purpose at the trip destination")
     oadtyp: int = Field(ge=1, le=6, description="Trip origin address type")
     dadtyp: int = Field(ge=1, le=6, description="Trip destination address type")
-    opcl: int | None = Field(ge=-1, description="Trip origin parcel ID")
-    otaz: int | None = Field(ge=-1, description="Trip origin zone ID")
+    opcl: int = Field(ge=-1, description="Trip origin parcel ID")
+    otaz: int = Field(ge=-1, description="Trip origin zone ID")
     oxco: float = Field(ge=-9999, le=9999, description="Trip origin X coordinate")
     oyco: float = Field(ge=-9999, le=9999, description="Trip origin Y coordinate")
-    dpcl: int | None = Field(ge=-1, description="Trip destination parcel ID")
-    dtaz: int | None = Field(ge=-1, description="Trip destination zone ID")
+    dpcl: int = Field(ge=-1, description="Trip destination parcel ID")
+    dtaz: int = Field(ge=-1, description="Trip destination zone ID")
     dxco: float = Field(ge=-9999, le=9999, description="Trip destination X coordinate")
     dyco: float = Field(ge=-9999, le=9999, description="Trip destination Y coordinate")
     mode: DaysimMode = Field(description="Trip mode")

--- a/src/processing/formatting/daysim/format_days.py
+++ b/src/processing/formatting/daysim/format_days.py
@@ -200,11 +200,6 @@ def format_days(
             pl.lit(0).cast(pl.Int16).alias("mestops"),
             # Work at home (placeholder)
             pl.lit(0).cast(pl.Int16).alias("wkathome"),
-            # Location coordinates
-            pl.col("work_lon").alias("pwxco"),
-            pl.col("work_lat").alias("pwyco"),
-            pl.col("school_lon").alias("psxco"),
-            pl.col("school_lat").alias("psyco"),
             # Expansion factor
             pl.col("day_weight").fill_null(0).alias("pdexpfac"),
         ]

--- a/src/processing/formatting/daysim/format_persons.py
+++ b/src/processing/formatting/daysim/format_persons.py
@@ -220,10 +220,10 @@ def format_persons(persons: pl.DataFrame, days: pl.DataFrame) -> pl.DataFrame:
         .otherwise(pl.lit(-1)),
         pwxco=pl.when(pl.col("pwtyp") != DaysimWorkerType.NON_WORKER.value)
         .then(pl.col("pwxco"))
-        .otherwise(pl.lit(None)),
+        .otherwise(pl.lit(-1)),
         pwyco=pl.when(pl.col("pwtyp") != DaysimWorkerType.NON_WORKER.value)
         .then(pl.col("pwyco"))
-        .otherwise(pl.lit(None)),
+        .otherwise(pl.lit(-1)),
         pstaz=pl.when(pl.col("pstyp") != DaysimStudentType.NOT_STUDENT.value)
         .then(pl.col("pstaz"))
         .otherwise(pl.lit(-1)),
@@ -232,10 +232,10 @@ def format_persons(persons: pl.DataFrame, days: pl.DataFrame) -> pl.DataFrame:
         .otherwise(pl.lit(-1)),
         psxco=pl.when(pl.col("pstyp") != DaysimStudentType.NOT_STUDENT.value)
         .then(pl.col("psxco"))
-        .otherwise(pl.lit(None)),
+        .otherwise(pl.lit(-1)),
         psyco=pl.when(pl.col("pstyp") != DaysimStudentType.NOT_STUDENT.value)
         .then(pl.col("psyco"))
-        .otherwise(pl.lit(None)),
+        .otherwise(pl.lit(-1)),
     )
 
     # If person weight is in data, use that, else default to 1.0

--- a/src/processing/formatting/daysim/format_trips.py
+++ b/src/processing/formatting/daysim/format_trips.py
@@ -512,6 +512,11 @@ def _prepare_basic_fields(linked_trips: pl.DataFrame, persons: pl.DataFrame) -> 
             # Map purposes
             pl.col("opurp").replace(PURPOSE_MAP).alias("opurp"),
             pl.col("dpurp").replace(PURPOSE_MAP).alias("dpurp"),
+            # Fill the usual nulls when zones are not matched (out of area, missing data, etc.)
+            pl.col("otaz").fill_null(-1),
+            pl.col("opcl").fill_null(-1),
+            pl.col("dtaz").fill_null(-1),
+            pl.col("dpcl").fill_null(-1),
         ]
     )
 


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Check all that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass
- [ ] Added new tests to cover changes
- [x] Manually tested the changes

## Checklist
<!-- Check all that apply -->
- [x] My code follows the style guidelines of this project (runs `ruff check .` without errors)
- [x] My code is properly formatted (runs `ruff format .`)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Related Issues
Closes #41

## Additional Notes
This pull request updates the Daysim data models and formatting logic to standardize the handling of missing or null values, particularly for location and zone fields. The changes ensure that missing values are consistently represented as `-1` for integer fields and `0.0` for float fields, improving data integrity and compatibility across the pipeline.

**Data model updates:**

- **Household and Person models:**  
  * Relaxed lower bounds for `hhparcel` and `hhtaz` in `HouseholdDaysimModel` from `1` to `-1` to allow for missing data representation.
  * Removed optional school and work coordinate fields from `PersonDaysimModel`, as these are now handled in the day-level model.

- **Person-day and Trip models:**  
  * Changed `pwxco`, `pwyco`, `psxco`, and `psyco` in `PersonDayDaysimModel` from optional floats to required floats with a default value of `0.0`, standardizing missing coordinate handling.
  * Made `opcl`, `otaz`, `dpcl`, and `dtaz` in `LinkedTripDaysimModel` required integers with a minimum of `-1` instead of optional, ensuring missing zones/parcels are represented as `-1`.

**Formatting logic updates:**

- **Person and trip formatting:**  
  * Updated `format_persons.py` to use `-1` instead of `None` for missing school/work location and zone fields (`pwxco`, `pwyco`, `psxco`, `psyco`). [[1]](diffhunk://#diff-d87c9f34fa4ee9f747a1dd3c8f55a61c30ac2d842f06515ad6d82e67136d2613L223-R226) [[2]](diffhunk://#diff-d87c9f34fa4ee9f747a1dd3c8f55a61c30ac2d842f06515ad6d82e67136d2613L235-R238)
  * Updated `format_trips.py` to fill nulls for trip origin/destination zone and parcel fields (`otaz`, `opcl`, `dtaz`, `dpcl`) with `-1`.

- **DaySim formatting and validation:**  
  * Removed school and work coordinate columns from the day-level output in `format_days.py`, aligning with the model changes.
  * Enabled output validation for the `format_daysim` step in the pipeline configuration.
