### PR TITLE
Snap unmatched points to nearest zone within a configured distance

### DIFF
--- a/projects/bats_2019/config.yaml
+++ b/projects/bats_2019/config.yaml
@@ -74,6 +74,8 @@ steps:
     validate_input: true
     cache: true
     params:
+      projected_crs: "EPSG:26910"  # UTM Zone 10N (Bay Area metric CRS for nearest-zone fallback)
+      max_snap_distance: 500  # metres; points farther from all zone boundaries remain null (out-of-region)
       zone_geographies:
         - zone_name: "taz"  # Primary TAZ for DaySim (TM1)
           shapefile: "{{ TM2_shapefile_dir }}/tazs_TM2_2_5.shp"

--- a/projects/bats_2023/config.yaml
+++ b/projects/bats_2023/config.yaml
@@ -315,6 +315,8 @@ steps:
     validate_input: false
     cache: true
     params:
+      projected_crs: "EPSG:26910"  # UTM Zone 10N (Bay Area metric CRS for nearest-zone fallback)
+      max_snap_distance: 500  # metres; points farther from all zone boundaries remain null (out-of-region)
       zone_geographies:
         - zone_name: "taz"  # Primary TAZ for DaySim (TM1)
           shapefile: "{{ TM2_shapefile_dir }}/tazs_TM2_2_5.shp"

--- a/src/processing/add_zone_ids/add_zone_ids.py
+++ b/src/processing/add_zone_ids/add_zone_ids.py
@@ -19,8 +19,52 @@ def add_zone_to_dataframe(
     lat_col: str,
     zone_col_name: str,
     zone_id_field: str,
+    projected_crs: str | None = None,
+    max_snap_distance: float | None = None,
 ) -> pl.DataFrame:
-    """Add zone ID to dataframe based on lon/lat coordinates."""
+    """Add a zone ID column to a Polars DataFrame via point-in-polygon spatial join.
+
+    Each row's lon/lat coordinates are matched against the provided zone shapefile.
+    If a point falls within exactly one zone polygon it receives that zone's ID.
+
+    Nearest-neighbour fallback
+    --------------------------
+    If ``projected_crs`` is provided, any unmatched point is snapped to the
+    *nearest* zone polygon (by boundary distance) instead of being left null.
+    Supply a metric CRS such as ``"EPSG:26910"`` (UTM Zone 10N for the Bay
+    Area); operating in degrees produces incorrect distances and triggers a
+    GeoPandas warning.  When ``projected_crs`` is ``None`` no snapping is
+    performed and unmatched points are left null with a WARNING logged.
+
+    Use ``max_snap_distance`` (in ``projected_crs`` units, i.e. metres for
+    UTM) to distinguish GPS-drift edge cases from genuinely out-of-region
+    points: a point is snapped only when the distance to the nearest zone
+    boundary is ≤ ``max_snap_distance``; points farther away are left null.
+    ``max_snap_distance=None`` snaps all unmatched points regardless of
+    distance.
+
+    Args:
+        df: Input Polars DataFrame.
+        shp: Zone boundary GeoDataFrame (any CRS; will be reprojected as needed).
+        df_index: Name of the unique-ID column in ``df`` used for joining back.
+        lon_col: Name of the longitude column in ``df`` (WGS-84 assumed).
+        lat_col: Name of the latitude column in ``df`` (WGS-84 assumed).
+        zone_col_name: Name for the output zone-ID column added to ``df``.
+        zone_id_field: Field name in ``shp`` that holds the zone ID values.
+        projected_crs: EPSG string for the metric CRS used during the
+            nearest-neighbour fallback (e.g. ``"EPSG:26910"``).  If ``None``,
+            no fallback is performed and unmatched points remain null.
+        max_snap_distance: Maximum distance (in ``projected_crs`` units, i.e.
+            metres for UTM) within which an unmatched point is snapped to the
+            nearest zone polygon.  Points farther than this are left null
+            (assumed to be genuinely out-of-region rather than near a zone
+            edge).  ``None`` means no distance limit — all unmatched points
+            are snapped.  Only used when ``projected_crs`` is provided.
+
+    Returns:
+        ``df`` with a new ``zone_col_name`` column appended.  The column dtype
+        is ``Int64`` when all non-null values are numeric, otherwise ``Utf8``.
+    """
     # Convert to GeoDataFrame
     # Keep just index to avoid corrupting original polars DataFrame with pandas nonsense
     gdf = gpd.GeoDataFrame(
@@ -38,6 +82,63 @@ def add_zone_to_dataframe(
     # Spatial join to find zone containing each point
     gdf_joined = gpd.sjoin(gdf, shp_prepared, how="left", predicate="within")
     gdf_joined = gdf_joined.rename(columns={zone_id_field: zone_col_name})
+
+    # Fallback: for points that didn't fall within any zone, snap to the nearest zone
+    # polygon by boundary distance. Only performed when projected_crs is provided.
+    # max_snap_distance filters out genuinely out-of-region points: only snap if the
+    # point is within that distance of the nearest zone boundary.
+    null_mask = gdf_joined[zone_col_name].isna()
+    if null_mask.any():
+        n_null = null_mask.sum()
+        if projected_crs:
+            # Project to metric CRS before nearest-neighbour join
+            # to avoid incorrect results from operating in geographic CRS (degrees).
+            # make_valid() repairs self-intersecting rings that cause GEOSException
+            # in shapely's query_nearest when using polygon geometries directly.
+            shp_for_nearest = shp_prepared.to_crs(projected_crs)
+            shp_for_nearest["geometry"] = shp_for_nearest.geometry.make_valid()
+            points_projected = gdf[null_mask].to_crs(projected_crs)
+            # Exclude points with null/NaN coordinates (e.g. persons with no work location);
+            # those have no real location and should remain null regardless.
+            valid_geom_mask = (
+                points_projected.geometry.is_valid & ~points_projected.geometry.is_empty
+            )
+            points_for_nearest = points_projected[valid_geom_mask]
+            if not points_for_nearest.empty:
+                nearest = gpd.sjoin_nearest(
+                    points_for_nearest,
+                    shp_for_nearest,
+                    how="left",
+                    max_distance=max_snap_distance,
+                ).rename(columns={zone_id_field: zone_col_name})
+                # Drop duplicate rows that arise when multiple zones are equidistant
+                nearest = nearest[~nearest.index.duplicated(keep="first")]
+                n_snapped = nearest[zone_col_name].notna().sum()
+                n_beyond = len(points_for_nearest) - n_snapped
+                if n_snapped > 0:
+                    logger.warning(
+                        "%d point(s) did not fall within any %s zone; snapped to nearest zone.",
+                        n_snapped,
+                        zone_col_name,
+                    )
+                if n_beyond > 0:
+                    logger.warning(
+                        "%d point(s) did not fall within any %s zone and exceeded the snap"
+                        " distance of %.0f m; leaving as null.",
+                        n_beyond,
+                        zone_col_name,
+                        max_snap_distance,
+                    )
+                gdf_joined.loc[points_for_nearest.index, zone_col_name] = nearest[
+                    zone_col_name
+                ].values
+        else:
+            logger.warning(
+                "%d point(s) did not fall within any %s zone; leaving as null.",
+                n_null,
+                zone_col_name,
+            )
+
     gdf_joined = gdf_joined.drop(columns="geometry")
 
     # If all zone IDs are integers, convert to Int64 to allow nulls
@@ -73,6 +174,8 @@ def add_zone_ids(
     linked_trips: pl.DataFrame | None = None,
     tours: pl.DataFrame | None = None,
     joint_trips: pl.DataFrame | None = None,
+    projected_crs: str | None = None,
+    max_snap_distance: float | None = None,
 ) -> dict:
     """Add zone IDs for multiple geographic levels based on locations.
 
@@ -94,6 +197,13 @@ def add_zone_ids(
             - shapefile: Path to shapefile with zone boundaries (str)
             - zone_id_field: Field name in shapefile for zone ID
             - zone_name: Short name for zone type (e.g., 'taz', 'maz', 'county')
+        projected_crs: Optional EPSG string (e.g. 'EPSG:26910') for the metric
+            CRS to use when snapping unmatched points to the nearest zone.
+            If None, no nearest-zone fallback is performed.
+        max_snap_distance: Maximum snap distance in ``projected_crs`` units
+            (metres for UTM).  Unmatched points farther than this from all
+            zone boundaries are left null (assumed out-of-region).  None
+            means no distance limit.  Only used when ``projected_crs`` is set.
 
     Returns:
         Dictionary with updated dataframes
@@ -174,6 +284,8 @@ def add_zone_ids(
                 lat_col=lat_col,
                 zone_col_name=output_col,
                 zone_id_field=zone_id_field,
+                projected_crs=projected_crs,
+                max_snap_distance=max_snap_distance,
             )
 
     return results


### PR DESCRIPTION
Points that fall outside every zone polygon previously got a null zone ID silently. When `projected_crs` is set, unmatched points are now reprojected to a metric CRS and snapped to the nearest zone via sjoin_nearest, bounded by `max_snap_distance`; points beyond that limit stay null. Both paths now log a warning with counts.

Gated on `projected_crs` (default None), so configs that omit it are unchanged. The BATS 2019/2023 configs enable it (EPSG:26910 / 500m), which means previously-null taz/maz/county values become populated for those runs.

Extracted from tm1.7_calibration (27b1347, plus the add_zone_ids lint hunk of ac287e8) so the behavior change is reviewed on its own.

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Check all that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass
- [ ] Added new tests to cover changes
- [x] Manually tested the changes

## Checklist
<!-- Check all that apply -->
- [x] My code follows the style guidelines of this project (runs `ruff check .` without errors)
- [x] My code is properly formatted (runs `ruff format .`)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Related Issues
<!-- Link any related issues here using #issue_number -->
Closes #

## Additional Notes
<!-- Add any additional notes or context about the PR here -->
