### PR TITLE
Key joint_tour_id on trip occasion; drop singleton joint tours

### DIFF
--- a/src/processing/tours/joint_tour_helpers.py
+++ b/src/processing/tours/joint_tour_helpers.py
@@ -130,6 +130,23 @@ def identify_joint_tours(
     # Assign joint_tour_id to tours sharing the same stable group
     tours_with_joint_id = _assign_joint_tour_ids(valid_joint_tours)
 
+    # Safety check: a joint_tour_id must be shared by at least 2 persons.
+    # In edge cases, only one person's tour may survive eligibility filters
+    # for a given occasion. Those singleton IDs are reset to null.
+    valid_joint_ids = (
+        tours_with_joint_id.group_by("joint_tour_id")
+        .agg(pl.col("person_id").n_unique().alias("num_persons"))
+        .filter(pl.col("num_persons") >= 2)  # noqa: PLR2004
+        .select("joint_tour_id")
+    )
+
+    tours_with_joint_id = tours_with_joint_id.with_columns(
+        pl.when(pl.col("joint_tour_id").is_in(valid_joint_ids["joint_tour_id"].implode()))
+        .then(pl.col("joint_tour_id"))
+        .otherwise(pl.lit(None, dtype=pl.Int64))
+        .alias("joint_tour_id")
+    )
+
     # Join joint_tour_id back to original tables
     linked_trips = linked_trips.join(
         tours_with_joint_id.select(["person_id", "tour_id", "joint_tour_id"]),

--- a/src/processing/tours/joint_tour_helpers.py
+++ b/src/processing/tours/joint_tour_helpers.py
@@ -213,6 +213,8 @@ def _find_stable_groups_per_tour(
             [
                 # Collect all participant lists
                 pl.col("participants").alias("all_trip_participants"),
+                # Collect joint_trip_ids for this tour occasion
+                pl.col("joint_trip_ids").alias("joint_trip_ids_list"),
             ]
         )
         .with_columns(
@@ -231,6 +233,14 @@ def _find_stable_groups_per_tour(
         .with_columns(
             [
                 pl.col("stable_group").list.len().alias("stable_group_size"),
+                # Flatten and deduplicate joint_trip_ids (each exploded row has one id,
+                # so collected column is a flat list of integers)
+                pl.col("joint_trip_ids_list")
+                .map_elements(
+                    lambda ids: sorted(set(ids)),
+                    return_dtype=pl.List(pl.Int64),
+                )
+                .alias("joint_trip_ids"),
             ]
         )
     )
@@ -241,10 +251,12 @@ def _find_stable_groups_per_tour(
 def _assign_joint_tour_ids(
     valid_joint_tours: pl.DataFrame,
 ) -> pl.DataFrame:
-    """Assign joint_tour_id to tours sharing the same stable group.
+    """Assign joint_tour_id to tours with same joint trip occasion.
 
-    Tours with identical stable groups (same people) get the same
-    joint_tour_id. IDs follow pattern: <hh_id><2-digit-sequence>
+    Tours that share the exact same set of joint_trip_ids are the same
+    occasion and get the same joint_tour_id. The same stable group on a
+    different occasion will have different joint_trip_ids and thus a
+    different joint_tour_id. IDs follow pattern: <hh_id><2-digit-sequence>
 
     Args:
         valid_joint_tours: Tours with stable groups of 2+ people
@@ -252,11 +264,13 @@ def _assign_joint_tour_ids(
     Returns:
         DataFrame with person_id, tour_id, joint_tour_id
     """
-    # Create a canonical group identifier (sorted participant list as string)
-    # This lets us group tours with identical participants
+    # Use sorted joint_trip_ids as the group key.
+    # Two persons on the same joint tour occasion share identical joint_trip_ids,
+    # so they get the same group_key and thus the same joint_tour_id.
+    # The same stable group on a different occasion has different joint_trip_ids.
     tours_with_group_key = valid_joint_tours.with_columns(
         [
-            pl.col("stable_group")
+            pl.col("joint_trip_ids")
             .map_elements(
                 lambda x: "_".join(map(str, sorted(x))),
                 return_dtype=pl.String,

--- a/src/processing/tours/joint_tour_helpers.py
+++ b/src/processing/tours/joint_tour_helpers.py
@@ -7,11 +7,16 @@ records in the canonical data model.
 
 Algorithm:
 ----------
-1. For each person's tour, collect all joint_trip_ids and extract participants
-2. Check if a stable group of 2+ people exists for ALL trips in the tour
-3. If so, assign joint_tour_id linking those individual tours together
-4. Handle partial dropoffs: if 3 people start but 1 drops off, remaining 2
-   can still form a joint tour if they stay together for the entire tour
+1. Find eligible tours: every trip in the tour is joint, and there are 2+ trips
+2. Count the tour's stable group: participants present on ALL of its joint trips
+3. Keep tours whose stable group has 2+ people
+4. Assign joint_tour_id per occasion: tours sharing the same set of
+   joint_trip_ids are the same outing and get the same id
+5. Drop singletons: an id held by only one person is not a joint tour
+
+Every step works off ``linked_trips``' existing (person_id, tour_id,
+joint_trip_id) relation, so participation stays a row-per-fact join rather than
+being collapsed into list columns.
 
 Example:
 --------
@@ -24,6 +29,9 @@ Person A, B, C depart, C drops off:
   - Trip 1: A,B,C -> school (joint_trip_id=1001)
   - Trip 2: A,B -> home (joint_trip_id=1002)
   Result: A and B get joint_tour_id (stable pair), C gets NULL
+
+The same pair on two separate outings get two different joint_tour_ids, because
+the outings have different joint_trip_ids.
 """
 
 import logging
@@ -33,6 +41,11 @@ import polars as pl
 from utils.create_ids import create_concatenated_id
 
 logger = logging.getLogger(__name__)
+
+# A tour needs at least this many trips to establish a pattern of travelling together
+MIN_TRIPS_FOR_JOINT_TOUR = 2
+# A joint tour needs at least this many participants, by definition
+MIN_JOINT_TOUR_PARTICIPANTS = 2
 
 
 def identify_joint_tours(
@@ -54,98 +67,44 @@ def identify_joint_tours(
     """
     logger.info("Identifying joint tours from joint trips...")
 
-    # Filter to only trips that are part of tours
     trips_with_tours = linked_trips.filter(pl.col("tour_id").is_not_null())
-
-    # Count total trips per (person_id, tour_id)
-    total_trips_per_tour = trips_with_tours.group_by(["person_id", "tour_id"]).agg(
-        [pl.col("linked_trip_id").count().alias("total_num_trips")]
-    )
-
-    # Filter to only trips that are joint
     joint_trip_members = trips_with_tours.filter(pl.col("joint_trip_id").is_not_null())
 
-    if len(joint_trip_members) == 0:
+    if joint_trip_members.is_empty():
         logger.info("No joint trips found, skipping joint tour identification")
-        # Add null joint_tour_id columns
-        linked_trips = linked_trips.with_columns(
-            pl.lit(None, dtype=pl.Int64).alias("joint_tour_id")
-        )
-        tours = tours.with_columns(pl.lit(None, dtype=pl.Int64).alias("joint_tour_id"))
-        return linked_trips, tours
+        return _without_joint_tours(linked_trips, tours)
 
-    # For each (person_id, tour_id), collect all joint_trip_ids
-    tour_joint_trips = joint_trip_members.group_by(["person_id", "tour_id"]).agg(
-        [
-            pl.col("hh_id").first(),
-            pl.col("joint_trip_id").unique().alias("joint_trip_ids"),
-            pl.col("linked_trip_id").count().alias("num_joint_trips"),
-        ]
-    )
+    eligible_tours = _find_eligible_tours(trips_with_tours, joint_trip_members)
 
-    # Join with total trip counts to filter tours where ALL trips are joint
-    tour_joint_trips_before_filter = tour_joint_trips.join(
-        total_trips_per_tour, on=["person_id", "tour_id"], how="left"
-    )
-
-    tour_joint_trips = tour_joint_trips_before_filter.filter(
-        # Only keep tours where all trips are joint
-        pl.col("num_joint_trips") == pl.col("total_num_trips")
-    )
-
-    # Also filter out single-trip tours - they can't form meaningful joint tours
-    # a tour needs at least 2 trips to establish a pattern of traveling together
-    tour_joint_trips = tour_joint_trips.filter(
-        pl.col("total_num_trips") >= 2  # noqa: PLR2004
-    )
-
-    if len(tour_joint_trips) == 0:
+    if eligible_tours.is_empty():
         logger.info("No tours where all trips are joint, skipping joint tour identification")
-        linked_trips = linked_trips.with_columns(
-            pl.lit(None, dtype=pl.Int64).alias("joint_tour_id")
-        )
-        tours = tours.with_columns(pl.lit(None, dtype=pl.Int64).alias("joint_tour_id"))
-        return linked_trips, tours
+        return _without_joint_tours(linked_trips, tours)
 
-    # Get participants for each joint_trip_id from the joint_trips table
-    # We need to extract who was on each joint trip
-    joint_trip_participants = _extract_joint_trip_participants(joint_trip_members)
-
-    # For each tour, check if there's a stable group throughout
-    tour_stable_groups = _find_stable_groups_per_tour(tour_joint_trips, joint_trip_participants)
-
-    # Filter to tours with stable groups of 2+ people
-    valid_joint_tours = tour_stable_groups.filter(
-        pl.col("stable_group_size") >= 2  # noqa: PLR2004
+    # One row per (tour, joint_trip_id). This is the relation linked_trips
+    # already holds; keep it long rather than collapsing to a list per tour.
+    tour_joint_trips = (
+        joint_trip_members.join(eligible_tours, on=["person_id", "tour_id"], how="inner")
+        .select(["person_id", "tour_id", "hh_id", "joint_trip_id"])
+        .unique()
     )
 
-    if len(valid_joint_tours) == 0:
+    stable_groups = _count_stable_participants(tour_joint_trips, joint_trip_members)
+    valid_joint_tours = stable_groups.filter(
+        pl.col("stable_group_size") >= MIN_JOINT_TOUR_PARTICIPANTS
+    )
+
+    if valid_joint_tours.is_empty():
         logger.info("No stable joint tour groups found")
-        linked_trips = linked_trips.with_columns(
-            pl.lit(None, dtype=pl.Int64).alias("joint_tour_id")
+        return _without_joint_tours(linked_trips, tours)
+
+    tours_with_joint_id = _assign_joint_tour_ids(
+        tour_joint_trips.join(
+            valid_joint_tours.select(["person_id", "tour_id"]),
+            on=["person_id", "tour_id"],
+            how="inner",
         )
-        tours = tours.with_columns(pl.lit(None, dtype=pl.Int64).alias("joint_tour_id"))
-        return linked_trips, tours
-
-    # Assign joint_tour_id to tours sharing the same stable group
-    tours_with_joint_id = _assign_joint_tour_ids(valid_joint_tours)
-
-    # Safety check: a joint_tour_id must be shared by at least 2 persons.
-    # In edge cases, only one person's tour may survive eligibility filters
-    # for a given occasion. Those singleton IDs are reset to null.
-    valid_joint_ids = (
-        tours_with_joint_id.group_by("joint_tour_id")
-        .agg(pl.col("person_id").n_unique().alias("num_persons"))
-        .filter(pl.col("num_persons") >= 2)  # noqa: PLR2004
-        .select("joint_tour_id")
     )
-
-    tours_with_joint_id = tours_with_joint_id.with_columns(
-        pl.when(pl.col("joint_tour_id").is_in(valid_joint_ids["joint_tour_id"].implode()))
-        .then(pl.col("joint_tour_id"))
-        .otherwise(pl.lit(None, dtype=pl.Int64))
-        .alias("joint_tour_id")
-    )
+    tours_with_joint_id = _drop_singleton_joint_tours(tours_with_joint_id)
 
     # Join joint_tour_id back to original tables
     linked_trips = linked_trips.join(
@@ -160,152 +119,136 @@ def identify_joint_tours(
         how="left",
     )
 
-    num_joint_tours = len(tours.filter(pl.col("joint_tour_id").is_not_null()))
-    num_unique_joint_tour_ids = (
-        tours.filter(pl.col("joint_tour_id").is_not_null()).select("joint_tour_id").n_unique()
-    )
+    joint_tours = tours.filter(pl.col("joint_tour_id").is_not_null())
     logger.info(
         "Identified %d individual tours as joint (%d unique joint tour groups)",
-        num_joint_tours,
-        num_unique_joint_tour_ids,
+        len(joint_tours),
+        joint_tours.select("joint_tour_id").n_unique(),
     )
 
     return linked_trips, tours
 
 
-def _extract_joint_trip_participants(
+def _without_joint_tours(
+    linked_trips: pl.DataFrame,
+    tours: pl.DataFrame,
+) -> tuple[pl.DataFrame, pl.DataFrame]:
+    """Add a null joint_tour_id column to both tables.
+
+    Args:
+        linked_trips: Trip data
+        tours: Tour-level records
+
+    Returns:
+        Tuple of (linked_trips, tours) each with a null joint_tour_id column
+    """
+    null_id = pl.lit(None, dtype=pl.Int64).alias("joint_tour_id")
+    return linked_trips.with_columns(null_id), tours.with_columns(null_id)
+
+
+def _find_eligible_tours(
+    trips_with_tours: pl.DataFrame,
     joint_trip_members: pl.DataFrame,
 ) -> pl.DataFrame:
-    """Extract participant list for each joint_trip_id.
+    """Find tours where every trip is joint and there are enough trips.
+
+    A tour only counts if all of its trips are joint - a tour with a solo leg is
+    not a joint tour. Single-trip tours are excluded because one trip cannot
+    establish a pattern of travelling together.
 
     Args:
-        joint_trip_members: Trips with joint_trip_id
+        trips_with_tours: All trips that belong to a tour
+        joint_trip_members: The subset of those trips that are joint
 
     Returns:
-        DataFrame with joint_trip_id and sorted participant person_ids
+        DataFrame of eligible (person_id, tour_id)
     """
-    # Get all person_ids for each joint_trip_id
-    participants = joint_trip_members.group_by("joint_trip_id").agg(
-        [
-            pl.col("person_id").unique().sort().alias("participants"),
-        ]
+    total_trips = trips_with_tours.group_by(["person_id", "tour_id"]).agg(
+        pl.col("linked_trip_id").count().alias("_total_trips")
+    )
+    joint_trips = joint_trip_members.group_by(["person_id", "tour_id"]).agg(
+        pl.col("linked_trip_id").count().alias("_joint_trips")
     )
 
-    return participants
+    return (
+        joint_trips.join(total_trips, on=["person_id", "tour_id"], how="left")
+        .filter(
+            (pl.col("_joint_trips") == pl.col("_total_trips"))
+            & (pl.col("_total_trips") >= MIN_TRIPS_FOR_JOINT_TOUR)
+        )
+        .select(["person_id", "tour_id"])
+    )
 
 
-def _find_stable_groups_per_tour(
+def _count_stable_participants(
     tour_joint_trips: pl.DataFrame,
-    joint_trip_participants: pl.DataFrame,
+    joint_trip_members: pl.DataFrame,
 ) -> pl.DataFrame:
-    """Find stable participant groups for each person's tour.
+    """Count the people present on ALL of a tour's joint trips.
 
-    A stable group exists if the same set of 2+ people participate in
-    ALL joint trips throughout the tour.
+    The stable group is the intersection of participants across the tour's joint
+    trips. Expressed relationally, a person is in it when the number of the
+    tour's joint trips they appear on equals the tour's joint trip count - so
+    someone who drops off partway is excluded.
 
     Args:
-        tour_joint_trips: Tours with their joint_trip_ids
-        joint_trip_participants: Participants for each joint_trip_id
+        tour_joint_trips: One row per (person_id, tour_id, hh_id, joint_trip_id)
+        joint_trip_members: Joint trips, used to resolve who was on each one
 
     Returns:
-        DataFrame with person_id, tour_id, stable_group (sorted list),
-        stable_group_size
+        DataFrame with person_id, tour_id, hh_id, stable_group_size
     """
-    # Explode joint_trip_ids to one row per (tour, joint_trip_id)
-    tour_trips_exploded = tour_joint_trips.explode("joint_trip_ids")
+    # Who was on each joint trip - the inverse of linked_trips.joint_trip_id
+    participants = joint_trip_members.select(
+        "joint_trip_id",
+        pl.col("person_id").alias("_participant"),
+    ).unique()
 
-    # Join participants for each joint_trip
-    tour_trips_with_participants = tour_trips_exploded.join(
-        joint_trip_participants,
-        left_on="joint_trip_ids",
-        right_on="joint_trip_id",
-        how="left",
+    trips_per_tour = tour_joint_trips.group_by(["person_id", "tour_id"]).agg(
+        pl.col("joint_trip_id").n_unique().alias("_n_trips")
     )
 
-    # For each tour, find intersection of participants across all trips
-    # This gives us the stable group (people present in ALL trips)
-    stable_groups = (
-        tour_trips_with_participants.group_by(["person_id", "tour_id", "hh_id"])
-        .agg(
-            [
-                # Collect all participant lists
-                pl.col("participants").alias("all_trip_participants"),
-                # Collect joint_trip_ids for this tour occasion
-                pl.col("joint_trip_ids").alias("joint_trip_ids_list"),
-            ]
-        )
-        .with_columns(
-            [
-                # Find intersection: people present in ALL trips
-                pl.col("all_trip_participants")
-                .map_elements(
-                    lambda lists: sorted(
-                        set.intersection(*[set(lst) for lst in lists]) if len(lists) > 0 else set()
-                    ),
-                    return_dtype=pl.List(pl.Int64),
-                )
-                .alias("stable_group"),
-            ]
-        )
-        .with_columns(
-            [
-                pl.col("stable_group").list.len().alias("stable_group_size"),
-                # Flatten and deduplicate joint_trip_ids (each exploded row has one id,
-                # so collected column is a flat list of integers)
-                pl.col("joint_trip_ids_list")
-                .map_elements(
-                    lambda ids: sorted(set(ids)),
-                    return_dtype=pl.List(pl.Int64),
-                )
-                .alias("joint_trip_ids"),
-            ]
-        )
+    return (
+        tour_joint_trips.join(participants, on="joint_trip_id", how="left")
+        .group_by(["person_id", "tour_id", "hh_id", "_participant"])
+        .agg(pl.col("joint_trip_id").n_unique().alias("_n_present"))
+        .join(trips_per_tour, on=["person_id", "tour_id"], how="left")
+        .filter(pl.col("_n_present") == pl.col("_n_trips"))
+        .group_by(["person_id", "tour_id", "hh_id"])
+        .agg(pl.col("_participant").n_unique().alias("stable_group_size"))
     )
-
-    return stable_groups
 
 
 def _assign_joint_tour_ids(
-    valid_joint_tours: pl.DataFrame,
+    tour_joint_trips: pl.DataFrame,
 ) -> pl.DataFrame:
-    """Assign joint_tour_id to tours with same joint trip occasion.
+    """Assign joint_tour_id to tours sharing the same joint trip occasion.
 
-    Tours that share the exact same set of joint_trip_ids are the same
-    occasion and get the same joint_tour_id. The same stable group on a
-    different occasion will have different joint_trip_ids and thus a
-    different joint_tour_id. IDs follow pattern: <hh_id><2-digit-sequence>
+    Tours that share the exact same set of joint_trip_ids are the same occasion
+    and get the same joint_tour_id. The same stable group on a different
+    occasion has different joint_trip_ids and so a different joint_tour_id.
+    IDs follow the pattern ``<hh_id><2-digit-sequence>``.
+
+    The occasion key is the tour's sorted joint_trip_ids joined into a string,
+    which is unique per set because the ids are sorted and delimited.
 
     Args:
-        valid_joint_tours: Tours with stable groups of 2+ people
+        tour_joint_trips: One row per (person_id, tour_id, hh_id, joint_trip_id)
 
     Returns:
         DataFrame with person_id, tour_id, joint_tour_id
     """
-    # Use sorted joint_trip_ids as the group key.
-    # Two persons on the same joint tour occasion share identical joint_trip_ids,
-    # so they get the same group_key and thus the same joint_tour_id.
-    # The same stable group on a different occasion has different joint_trip_ids.
-    tours_with_group_key = valid_joint_tours.with_columns(
-        [
-            pl.col("joint_trip_ids")
-            .map_elements(
-                lambda x: "_".join(map(str, sorted(x))),
-                return_dtype=pl.String,
-            )
-            .alias("group_key"),
-        ]
+    tours_with_group_key = tour_joint_trips.group_by(["person_id", "tour_id", "hh_id"]).agg(
+        pl.col("joint_trip_id").unique().sort().cast(pl.String).str.join("_").alias("group_key")
     )
 
-    # Assign sequential ID to each unique group within household
+    # Assign a sequential id to each unique occasion within the household
     unique_groups = (
         tours_with_group_key.select(["hh_id", "group_key"]).unique().sort(["hh_id", "group_key"])
     )
-
     unique_groups = unique_groups.with_columns(
         pl.col("group_key").rank(method="dense").over("hh_id").alias("joint_tour_num")
     )
-
-    # Create standardized joint_tour_id: <hh_id> + <2 digit enumerator>
     unique_groups = create_concatenated_id(
         unique_groups,
         output_col="joint_tour_id",
@@ -314,11 +257,42 @@ def _assign_joint_tour_ids(
         sequence_padding=2,
     )
 
-    # Join back to tours
-    tours_with_joint_id = tours_with_group_key.join(
+    return tours_with_group_key.join(
         unique_groups.select(["hh_id", "group_key", "joint_tour_id"]),
         on=["hh_id", "group_key"],
         how="left",
+    ).select(["person_id", "tour_id", "joint_tour_id"])
+
+
+def _drop_singleton_joint_tours(
+    tours_with_joint_id: pl.DataFrame,
+) -> pl.DataFrame:
+    """Null out any joint_tour_id shared by fewer than two persons.
+
+    In edge cases only one person's tour survives the eligibility filters for a
+    given occasion, which would leave a joint tour with a single participant.
+
+    Args:
+        tours_with_joint_id: DataFrame with person_id, tour_id, joint_tour_id
+
+    Returns:
+        The same frame with singleton joint_tour_ids set to null
+    """
+    shared_ids = (
+        tours_with_joint_id.group_by("joint_tour_id")
+        .agg(pl.col("person_id").n_unique().alias("_n_persons"))
+        .filter(pl.col("_n_persons") >= MIN_JOINT_TOUR_PARTICIPANTS)
+        .select("joint_tour_id")
+        .with_columns(pl.lit(value=True).alias("_shared"))
     )
 
-    return tours_with_joint_id.select(["person_id", "tour_id", "joint_tour_id"])
+    return (
+        tours_with_joint_id.join(shared_ids, on="joint_tour_id", how="left")
+        .with_columns(
+            pl.when(pl.col("_shared").fill_null(value=False))
+            .then(pl.col("joint_tour_id"))
+            .otherwise(pl.lit(None, dtype=pl.Int64))
+            .alias("joint_tour_id")
+        )
+        .drop("_shared")
+    )

--- a/tests/test_joint_tours.py
+++ b/tests/test_joint_tours.py
@@ -25,6 +25,7 @@ from data_canon.codebook.trips import Driver, ModeType, Purpose, PurposeCategory
 from processing import link_trips
 from processing.joint_trips import detect_joint_trips
 from processing.tours.extraction import extract_tours
+from processing.tours.joint_tour_helpers import identify_joint_tours
 
 
 @pytest.fixture
@@ -559,6 +560,98 @@ class TestPartialDropoff:
             assert child_joint["joint_tour_id"][0] != parent_joint_ids[0], (
                 "Child should not share parents' joint_tour_id"
             )
+
+
+HH_ID = 23000075
+P1 = 23000075001
+P2 = 23000075002
+
+
+def _build_joint_tour_frames(
+    trips: list[tuple[int, int, int, int | None]],
+) -> tuple[pl.DataFrame, pl.DataFrame]:
+    """Build minimal linked_trips/tours frames for identify_joint_tours.
+
+    Args:
+        trips: (linked_trip_id, person_id, tour_id, joint_trip_id) rows.
+
+    Returns:
+        Tuple of (linked_trips, tours).
+    """
+    linked_trips = pl.DataFrame(
+        {
+            "linked_trip_id": [t[0] for t in trips],
+            "person_id": [t[1] for t in trips],
+            "tour_id": [t[2] for t in trips],
+            "joint_trip_id": [t[3] for t in trips],
+            "hh_id": [HH_ID] * len(trips),
+        },
+        schema_overrides={"joint_trip_id": pl.Int64},
+    )
+    tours = pl.DataFrame({"tour_id": sorted({t[2] for t in trips})})
+    return linked_trips, tours
+
+
+class TestJointTourOccasions:
+    """Test that joint_tour_id distinguishes occasions, not participant groups."""
+
+    def test_same_pair_two_occasions_get_different_ids(self):
+        """The same pair travelling twice should get one joint_tour_id per occasion.
+
+        joint_tour_id is keyed on the set of joint_trip_ids (the occasion), so the
+        same stable group on a second outing is a distinct joint tour rather than a
+        continuation of the first.
+        """
+        # Occasion 1 = joint trips 1001/1002; occasion 2 = joint trips 1003/1004.
+        linked_trips, tours = _build_joint_tour_frames(
+            [
+                (1, P1, 101, 1001),
+                (2, P1, 101, 1002),
+                (3, P2, 201, 1001),
+                (4, P2, 201, 1002),
+                (5, P1, 102, 1003),
+                (6, P1, 102, 1004),
+                (7, P2, 202, 1003),
+                (8, P2, 202, 1004),
+            ]
+        )
+
+        _, tours_out = identify_joint_tours(linked_trips, tours)
+
+        ids = dict(zip(tours_out["tour_id"], tours_out["joint_tour_id"], strict=True))
+        assert all(v is not None for v in ids.values()), "All four tours should be joint"
+
+        # Partners on the same occasion share an id...
+        assert ids[101] == ids[201], "Occasion 1 partners should share a joint_tour_id"
+        assert ids[102] == ids[202], "Occasion 2 partners should share a joint_tour_id"
+
+        # ...but the two occasions are distinct joint tours.
+        assert ids[101] != ids[102], (
+            "The same pair on a second occasion should get a different joint_tour_id"
+        )
+
+    def test_singleton_joint_tour_id_is_nulled(self):
+        """A joint_tour_id surviving for only one person is reset to null.
+
+        P2's tour has a non-joint trip, so it fails the all-trips-joint filter. That
+        leaves P1's tour as the only member of the occasion; a joint tour needs 2+
+        participants, so the id is dropped rather than left as a singleton.
+        """
+        linked_trips, tours = _build_joint_tour_frames(
+            [
+                (1, P1, 101, 1001),
+                (2, P1, 101, 1002),
+                (3, P2, 201, 1001),
+                (4, P2, 201, 1002),
+                (5, P2, 201, None),  # non-joint trip disqualifies P2's tour
+            ]
+        )
+
+        _, tours_out = identify_joint_tours(linked_trips, tours)
+
+        assert tours_out["joint_tour_id"].null_count() == len(tours_out), (
+            "A joint_tour_id held by a single person should be nulled"
+        )
 
 
 class TestNoJointTours:


### PR DESCRIPTION
## Description

Extracted from `tm1.7_calibration` (`3ca7c5c`, `d53c558`, authored by Melody Tsao). Part of splitting core-pipeline changes out of that branch so they get reviewed as pipeline changes rather than as CT-RAMP calibration.

**Base:** `develop` · **Independent** of the other core PRs.

Three changes to joint tour identification — the first two extracted verbatim, the third a refactor on top:

**1. `joint_tour_id` now identifies an occasion, not a participant group.**
`_assign_joint_tour_ids` previously grouped on `stable_group` (the sorted participant list), so the same set of people on two different outings received the *same* `joint_tour_id`. The group key is now the sorted set of `joint_trip_ids`, so each occasion gets its own id.

**2. Singleton joint tours are nulled.**
A joint tour needs 2+ participants by definition, but eligibility filters could leave one person's tour as the sole survivor of an occasion — keeping an id with a single participant. Any `joint_tour_id` with `< 2` unique persons is now reset to null.


**3. Derive joint tours from the trip relation instead of list columns.**

`linked_trips` already carries `(person_id, tour_id, joint_trip_id)` — the inverse FK. The module collapsed that relation into list columns and then paid Python to take it apart again: `set.intersection` over a list-of-lists for the stable group, `sorted(set(...))` to dedupe ids, and `"_".join(sorted(...))` for the occasion key. The lists were a round-trip, materialising a relation the table already expressed.

Now it works off the relation directly:

- **stable group** — a person is in it when the number of the tour's joint trips they appear on equals the tour's joint trip count. A relational count/filter rather than set algebra. (Only the *size* was ever used; the group itself never was.)
- **occasion key** — a native grouped string join over sorted ids, yielding a `String` column instead of a list built by a Python lambda.
- **eligibility** and the **singleton guard** moved into named helpers, so `identify_joint_tours` reads as the five steps in the module docstring.

This removes all three `map_elements` calls. develop had two; the occasion-keying commit added a third. `map_elements` is a row-wise Python UDF and is opaque to the query optimiser.

**Behaviour is unchanged**, verified two ways:

| check | result |
|---|---|
| 400 randomised household-days (dropoffs, solo legs, single-trip tours, multi-occasion days) | **identical `joint_tour_id` values** — not merely identical groupings |
| stable-group rewrite @ 48k tour rows | 2.115s → 0.074s (**28.5×**), identical output |
| occasion key construction | **7.2×**, byte-identical |

### ⚠️ Reviewer note

**This changes `joint_tour_id` values for all consumers**, not just CT-RAMP: ids differ, their cardinality differs, and some previously-populated ids become null. It propagates to `linked_trips`, where `joint_tour_id` is joined back. CT-RAMP consumes it (`format_households.py` joint tour frequency, `format_tours.py` individual-tour isolation), and DaySim/canonical consumers benefit identically — no CT-RAMP-only field is involved, which is why it's split out here.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring
- [x] Performance improvement

> Marked as breaking in the sense that **output values change**: `joint_tour_id` is a published field, and its values/nullability differ after this PR. No API or schema signature changes.

## Testing

- [x] All existing tests pass
- [x] Added new tests to cover changes
- [ ] Manually tested the changes

`uv run pytest` → **805 passed** (803 `develop` baseline + 2 new).

The existing suite passed **unchanged** against both original commits, so neither behavior was actually covered. Added two tests that fail against `develop`'s `joint_tour_helpers` and pass here:

- `test_same_pair_two_occasions_get_different_ids` — the same pair travelling twice previously reused the first tour's id.
- `test_singleton_joint_tour_id_is_nulled` — on `develop` this leaves tour 101 holding `joint_tour_id 2300007501` with no partner.

Both drive `identify_joint_tours` directly rather than `extract_tours`; the singleton case is not reachable through the full extraction path.

## Checklist

- [x] My code follows the style guidelines of this project (runs `ruff check .` without errors)
- [x] My code is properly formatted (runs `ruff format .`)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Related Issues

Part of the `tm1.7_calibration` core-pipeline split. Sibling PRs: #66 (output ordering), #67 (LabeledEnum — unblocks the CT-RAMP PR), #68 → #69 → #70 (linked-trip fields → tour destination → alternate-work detection). #63 (zone snapping) is merged.

## Additional Notes

`joint_tour_helpers.py` is **not** byte-identical to `tm1.7_calibration`'s version: the two behaviour commits are extracted verbatim, then refactored on top to drop the list-column round-trip (see item 3). The equivalence check above pins the output.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
