### PR TITLE
Sort written output tables by hh_id/person_id

### DIFF
--- a/projects/bats_2019/run.py
+++ b/projects/bats_2019/run.py
@@ -3,6 +3,7 @@
 import argparse
 import logging
 import os
+import shutil
 from pathlib import Path
 
 import polars as pl
@@ -104,17 +105,33 @@ if __name__ == "__main__":
         action="store_true",
         help="Clear the pipeline cache before running",
     )
+    parser.add_argument(
+        "--config",
+        default=None,
+        help="Path to the YAML config file (default: config.yaml next to this script)",
+    )
     args = parser.parse_args()
 
+    config_path = Path(args.config) if args.config else CONFIG_PATH
+
     logger.info("Starting BATS 2019 DaySim Processing Pipeline")
+    logger.info("Using config: %s", config_path)
 
     cache_dir = Path(".cache/2019")
     pipeline = Pipeline(
-        config_path=CONFIG_PATH,
+        config_path=config_path,
         steps=processing_steps,
         caching=cache_dir,
         log_file_mode="w" if args.clear_cache else "a",
     )
+
+    # Save a copy of the config used into the output directory
+    output_dir = pipeline.config.get("output_dir")
+    if output_dir:
+        saved_config = Path(output_dir) / "pipeline_2019.yaml"
+        Path(output_dir).mkdir(parents=True, exist_ok=True)
+        shutil.copy2(config_path, saved_config)
+        logger.info("Saved config copy to %s", saved_config)
 
     # Clear cache if requested
     if args.clear_cache and pipeline.cache:

--- a/projects/bats_2023/run.py
+++ b/projects/bats_2023/run.py
@@ -3,6 +3,7 @@
 import argparse
 import logging
 import os
+import shutil
 from pathlib import Path
 
 import polars as pl
@@ -132,18 +133,34 @@ if __name__ == "__main__":
         action="store_true",
         help="Clear the pipeline cache before running",
     )
+    parser.add_argument(
+        "--config",
+        default=None,
+        help="Path to the YAML config file (default: config.yaml next to this script)",
+    )
     args = parser.parse_args()
 
+    config_path = Path(args.config) if args.config else CONFIG_PATH
+
     logger.info("Starting BATS 2023 DaySim Processing Pipeline")
+    logger.info("Using config: %s", config_path)
 
     cache_dir = Path(".cache/2023")
     pipeline = Pipeline(
-        config_path=CONFIG_PATH,
+        config_path=config_path,
         steps=processing_steps,
         caching=cache_dir,
         data_models=new_models,
         log_file_mode="w" if args.clear_cache else "a",
     )
+
+    # Save a copy of the config used into the output directory
+    output_dir = pipeline.config.get("output_dir")
+    if output_dir:
+        saved_config = Path(output_dir) / "pipeline_2023.yaml"
+        Path(output_dir).mkdir(parents=True, exist_ok=True)
+        shutil.copy2(config_path, saved_config)
+        logger.info("Saved config copy to %s", saved_config)
 
     # Clear cache if requested
     if args.clear_cache and pipeline.cache:

--- a/src/processing/read_write/read_write.py
+++ b/src/processing/read_write/read_write.py
@@ -248,9 +248,12 @@ def write_data(  # noqa: C901
         # Sort by hh_id then person_id where available so related tables
         # (e.g. householdData and personData) are in the same order and
         # can be visually compared or joined without an extra sort step.
-        sort_cols = [c for c in ("hh_id", "person_id") if c in df.columns]
-        if sort_cols:
-            df = df.sort(sort_cols)
+        # Only polars frames: text outputs are plain strings, and geo outputs
+        # are GeoDataFrames, which sort via a different API.
+        if isinstance(df, pl.DataFrame):
+            sort_cols = [c for c in ("hh_id", "person_id") if c in df.columns]
+            if sort_cols:
+                df = df.sort(sort_cols)
 
         # Perform checks before writing
         if validate_input:

--- a/src/processing/read_write/read_write.py
+++ b/src/processing/read_write/read_write.py
@@ -200,7 +200,7 @@ def _write_checks(
 
 
 @step()
-def write_data(
+def write_data(  # noqa: C901
     output_paths: dict[str, str],
     canonical_data: CanonicalData,
     validate_input: bool,
@@ -244,6 +244,13 @@ def write_data(
 
         df = getattr(canonical_data, table)
         file_path = Path(path)
+
+        # Sort by hh_id then person_id where available so related tables
+        # (e.g. householdData and personData) are in the same order and
+        # can be visually compared or joined without an extra sort step.
+        sort_cols = [c for c in ("hh_id", "person_id") if c in df.columns]
+        if sort_cols:
+            df = df.sort(sort_cols)
 
         # Perform checks before writing
         if validate_input:


### PR DESCRIPTION
Extracted from `tm1.7_calibration` (read_write hunks of `3c82a3b` / `7340e55`, plus `ae7fd7d` and `94fed3a`). Part of splitting core-pipeline changes out of that branch so they get reviewed as pipeline changes rather than as CT-RAMP calibration.

**Base:** `develop` · **Independent** of the other core PRs.

## What changes

1. **`write_data` sorts every table** on `hh_id`/`person_id` (whichever are present) before writing, so related tables land in the same row order and can be compared side by side.
2. **`--config` CLI arg** for `bats_2019` and `bats_2023` `run.py`: point a run at an alternate YAML instead of the hardcoded `config.yaml`, and drop a copy of the config actually used into the output dir for provenance. Both projects are included so they don't drift apart.

## ⚠️ Reviewer notes

**The sort is ungated.** The motivation was comparing CT-RAMP `householdData` against `personData`, but the implementation is generic, so it **also reorders every DaySim and canonical output file**. Contents are unchanged as a set, but any diff-based check, checksum, or downstream tool relying on prior row order will see a difference. This is the one change in the core split that is both non-additive and unconditional — worth an explicit yes/no.

**Includes a bug fix.** As written on `tm1.7_calibration`, the sort assumed every output was a polars DataFrame. `write_data` also handles text outputs (plain `str`) and geo outputs (GeoDataFrames), so `df.columns` raised `AttributeError` and **crashed any run writing a `.txt` output**; GeoDataFrames would have failed on `df.sort()`, which is polars-only. Now guarded on `isinstance(df, pl.DataFrame)`.

This is caught by the existing `tests/test_read_write.py::TestWriteData::test_write_text_file`, **which fails on `tm1.7_calibration` today** — the bug is not introduced by this split, it just hasn't been hit because the current configs don't emit text outputs.

## Verification

- `uv run pytest` → **803 passed**, matching the `develop` baseline exactly.
- `uv run ruff check . && uv run ruff format --check .` → clean.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
