### PR TITLE
Detect alternate workplaces and fix work-based subtour detection

### DIFF
--- a/docs/codebook.md
+++ b/docs/codebook.md
@@ -26,6 +26,7 @@ print(purpose.label)  # "Appointment, shopping, or errands (e.g., gas)"
 ```
 
 ---
+::: data_canon.codebook.generic
 
 ::: data_canon.codebook.households
 

--- a/src/data_canon/codebook/generic.py
+++ b/src/data_canon/codebook/generic.py
@@ -28,9 +28,32 @@ class BooleanYesNo(LabeledEnum):
 
 
 class LocationType(LabeledEnum):
-    """Generic location type labels."""
+    """Classified location type of a trip end (origin or destination).
+
+    Assigned during tour extraction by matching each trip end against a person's
+    known locations (home, usual work, usual school) using purpose codes and
+    distance thresholds.
+    """
 
     HOME = (1, "Home")
+    """The person's home."""
+
     WORK = (2, "Work")
+    """The person's usual/reported workplace."""
+
     SCHOOL = (3, "School")
+    """The person's usual/reported school."""
+
     OTHER = (4, "Other")
+    """Any other location (shopping, social, errands, etc.)."""
+
+    ALTERNATE_WORK = (5, "Alternate work")
+    """A work location for the day that is *not* the person's usual workplace.
+
+    Assigned when the person did not visit their usual workplace that day but did
+    make work-related trips; the day's work location is taken to be the
+    work-related destination where they spent the most time. Trip ends at that
+    alternate location are marked ALTERNATE_WORK so the day's actual workplace is
+    visible, and the tour anchored there is treated as a work tour (rather than
+    work-related).
+    """

--- a/src/data_canon/models/survey.py
+++ b/src/data_canon/models/survey.py
@@ -210,10 +210,15 @@ class LinkedTripModel(BaseModel):
     )
     tour_direction: TourDirection = schema_field()
     o_location_type: LocationType = schema_field(
-        description="Classified location type of the trip origin (Home/Work/School/Other)."
+        description=(
+            "Classified location type of the trip origin (Home/Work/School/Other/Alternate work)."
+        ),
     )
     d_location_type: LocationType = schema_field(
-        description="Classified location type of the trip destination (Home/Work/School/Other)."
+        description=(
+            "Classified location type of the trip destination "
+            "(Home/Work/School/Other/Alternate work)."
+        ),
     )
     complete: bool | None = schema_field(default=None)
     linked_trip_weight: float | None = schema_field(default=None, ge=0)

--- a/src/processing/tours/aggregation_helpers.py
+++ b/src/processing/tours/aggregation_helpers.py
@@ -16,6 +16,7 @@ from data_canon.codebook.tours import (
     TourDirection,
     TourType,
 )
+from data_canon.codebook.trips import PurposeCategory
 from utils.helpers import expr_haversine
 
 from .priority_utils import (
@@ -63,6 +64,17 @@ def _calculate_tour_purp_and_dest(
         alias="_activity_duration",
     )
 
+    # Effective destination purpose: a destination classified as ALTERNATE_WORK
+    # (the day's work location when the usual workplace was not visited) is treated
+    # as WORK so the tour is classified as a work tour. WORK_RELATED errands
+    # elsewhere stay subtour activities.
+    effective_purpose = (
+        pl.when(pl.col("d_location_type") == LocationType.ALTERNATE_WORK)
+        .then(pl.lit(PurposeCategory.WORK.value))
+        .otherwise(pl.col("d_purpose_category"))
+    )
+    linked_trips = linked_trips.with_columns(effective_purpose.alias("_d_purpose_effective"))
+
     # Mark last trip (excluded from purpose selection)
     linked_trips = linked_trips.with_columns(
         [
@@ -83,7 +95,7 @@ def _calculate_tour_purp_and_dest(
 
     tour_purp_and_coords = non_last.group_by("tour_id", maintain_order=True).agg(
         [
-            pl.col("d_purpose_category").first().alias("tour_purpose"),
+            pl.col("_d_purpose_effective").first().alias("tour_purpose"),
             pl.col("d_lat").first().alias("_primary_d_lat"),
             pl.col("d_lon").first().alias("_primary_d_lon"),
             pl.col("d_location_type").first().alias("_primary_d_type"),
@@ -131,6 +143,8 @@ def _calculate_destination_times(
             pl.when(pl.col("_primary_d_type") == LocationType.HOME)
             .then(pl.lit(config.distance_thresholds[LocationType.HOME]))
             .when(pl.col("_primary_d_type") == LocationType.WORK)
+            .then(pl.lit(config.distance_thresholds[LocationType.WORK]))
+            .when(pl.col("_primary_d_type") == LocationType.ALTERNATE_WORK)
             .then(pl.lit(config.distance_thresholds[LocationType.WORK]))
             .when(pl.col("_primary_d_type") == LocationType.SCHOOL)
             .then(pl.lit(config.distance_thresholds[LocationType.SCHOOL]))

--- a/src/processing/tours/detection_helpers.py
+++ b/src/processing/tours/detection_helpers.py
@@ -11,6 +11,7 @@ import logging
 import polars as pl
 
 from data_canon.codebook.generic import LocationType
+from data_canon.codebook.trips import PurposeCategory
 from utils.helpers import expr_haversine
 
 logger = logging.getLogger(__name__)
@@ -215,18 +216,120 @@ def expand_anchor_periods(
     work_threshold = distance_thresholds[LocationType.WORK]
     school_threshold = distance_thresholds[LocationType.SCHOOL]
 
+    # --- Work "location for the day" -------------------------------------
+    # The work anchor is where the person actually worked that day, which may
+    # differ from their reported "usual" workplace:
+    #   * If they visited their usual workplace (a WORK-purpose trip, or a trip
+    #     within the work distance threshold of usual work), that is the day's
+    #     work location.
+    #   * Otherwise, if they made any WORK_RELATED trips, the day's work location
+    #     is the WORK_RELATED destination with the longest activity duration
+    #     (an "alternate workplace" day).
+    # This way WORK_RELATED errands *away* from the workplace look like leaving
+    # the anchor (so they become work-based subtours), while an alternate
+    # workplace is treated as the day's work anchor.
+
+    # Did the person visit their USUAL workplace this day?
+    linked_trips = linked_trips.with_columns(
+        (
+            (
+                (pl.col("o_purpose_category") == PurposeCategory.WORK.value)
+                | (pl.col("d_purpose_category") == PurposeCategory.WORK.value)
+                | (pl.col("_o_dist_to_usual_work") <= work_threshold)
+                | (pl.col("_d_dist_to_usual_work") <= work_threshold)
+            )
+            & pl.col("work_lat").is_not_null()
+        ).alias("_trip_touches_usual_work")
+    ).with_columns(
+        pl.col("_trip_touches_usual_work")
+        .any()
+        .over(["person_id", "day_id"])
+        .alias("_visited_usual_work")
+    )
+
+    # On days without a usual-work visit, choose the alternate workplace as the
+    # WORK_RELATED destination with the longest activity duration.
+    alt_work = (
+        linked_trips.filter(
+            ~pl.col("_visited_usual_work")
+            & (pl.col("d_purpose_category") == PurposeCategory.WORK_RELATED.value)
+        )
+        .sort(
+            ["person_id", "day_id", "d_activity_duration"],
+            descending=[False, False, True],
+        )
+        .group_by(["person_id", "day_id"], maintain_order=True)
+        .agg(
+            [
+                pl.col("d_lat").first().alias("_alt_work_lat"),
+                pl.col("d_lon").first().alias("_alt_work_lon"),
+            ]
+        )
+    )
+    linked_trips = linked_trips.join(alt_work, on=["person_id", "day_id"], how="left")
+
+    # Resolve the day's work coordinates and flag alternate-work days.
     linked_trips = linked_trips.with_columns(
         [
-            # Work anchor flags
+            pl.when(pl.col("_visited_usual_work"))
+            .then(pl.col("work_lat"))
+            .otherwise(pl.col("_alt_work_lat"))
+            .alias("_day_work_lat"),
+            pl.when(pl.col("_visited_usual_work"))
+            .then(pl.col("work_lon"))
+            .otherwise(pl.col("_alt_work_lon"))
+            .alias("_day_work_lon"),
+            (~pl.col("_visited_usual_work") & pl.col("_alt_work_lat").is_not_null()).alias(
+                "_is_alternate_work_day"
+            ),
+        ]
+    )
+
+    # Distance from each trip end to the day's work location.
+    linked_trips = linked_trips.with_columns(
+        [
+            expr_haversine(
+                pl.col("o_lat"),
+                pl.col("o_lon"),
+                pl.col("_day_work_lat"),
+                pl.col("_day_work_lon"),
+            ).alias("_o_dist_to_day_work"),
+            expr_haversine(
+                pl.col("d_lat"),
+                pl.col("d_lon"),
+                pl.col("_day_work_lat"),
+                pl.col("_day_work_lon"),
+            ).alias("_d_dist_to_day_work"),
+        ]
+    )
+
+    # "At the workplace": a WORK-purpose end on a usual-work day always counts,
+    # and any end within the work threshold of the day's work location counts.
+    # WORK_RELATED ends only count when physically at the day's work location, so
+    # WORK_RELATED errands elsewhere become subtours.
+    linked_trips = linked_trips.with_columns(
+        [
             (
-                (pl.col("_o_dist_to_usual_work") <= work_threshold)
-                & pl.col("work_lat").is_not_null()
-            ).alias("_o_at_usual_work"),
+                (
+                    pl.col("_visited_usual_work")
+                    & (pl.col("o_purpose_category") == PurposeCategory.WORK.value)
+                )
+                | (
+                    (pl.col("_o_dist_to_day_work") <= work_threshold)
+                    & pl.col("_day_work_lat").is_not_null()
+                )
+            ).alias("_o_at_workplace"),
             (
-                (pl.col("_d_dist_to_usual_work") <= work_threshold)
-                & pl.col("work_lat").is_not_null()
-            ).alias("_d_at_usual_work"),
-            # School anchor flags
+                (
+                    pl.col("_visited_usual_work")
+                    & (pl.col("d_purpose_category") == PurposeCategory.WORK.value)
+                )
+                | (
+                    (pl.col("_d_dist_to_day_work") <= work_threshold)
+                    & pl.col("_day_work_lat").is_not_null()
+                )
+            ).alias("_d_at_workplace"),
+            # School anchor flags (unchanged: distance to usual school)
             (
                 (pl.col("_o_dist_to_usual_school") <= school_threshold)
                 & pl.col("school_lat").is_not_null()
@@ -238,25 +341,40 @@ def expand_anchor_periods(
         ]
     )
 
-    # Determine if trip involves usual anchor (either end at anchor)
+    # Determine if trip involves an anchor (either end at anchor)
     linked_trips = linked_trips.with_columns(
         [
-            (pl.col("_o_at_usual_work") | pl.col("_d_at_usual_work")).alias("_at_usual_work"),
+            (pl.col("_o_at_workplace") | pl.col("_d_at_workplace")).alias("_at_workplace"),
             (pl.col("_o_at_usual_school") | pl.col("_d_at_usual_school")).alias("_at_usual_school"),
         ]
     )
 
-    # For each tour, find first and last trip at each anchor type
-    # Work anchor expansion
+    # Mark trip ends that are at an alternate workplace with LocationType.ALTERNATE_WORK
+    # so the day's actual (non-usual) work location is visible in o/d_location_type.
     linked_trips = linked_trips.with_columns(
         [
-            pl.when(pl.col("_at_usual_work"))
+            pl.when(pl.col("_o_at_workplace") & pl.col("_is_alternate_work_day"))
+            .then(pl.lit(LocationType.ALTERNATE_WORK))
+            .otherwise(pl.col("o_location_type"))
+            .alias("o_location_type"),
+            pl.when(pl.col("_d_at_workplace") & pl.col("_is_alternate_work_day"))
+            .then(pl.lit(LocationType.ALTERNATE_WORK))
+            .otherwise(pl.col("d_location_type"))
+            .alias("d_location_type"),
+        ]
+    )
+
+    # For each tour, find first and last trip at each anchor type
+    # Work anchor expansion (based on the day's work location)
+    linked_trips = linked_trips.with_columns(
+        [
+            pl.when(pl.col("_at_workplace"))
             .then(pl.col("_trip_num_in_tour"))
             .otherwise(None)
             .min()
             .over(["person_id", "day_id", "tour_num"])
             .alias("_work_period_start"),
-            pl.when(pl.col("_at_usual_work"))
+            pl.when(pl.col("_at_workplace"))
             .then(pl.col("_trip_num_in_tour"))
             .otherwise(None)
             .max()
@@ -309,7 +427,10 @@ def expand_anchor_periods(
         ]
     )
 
-    # Clean up temporary columns
+    # Clean up temporary columns. Keep _o_at_workplace / _d_at_workplace, which
+    # subtour detection reads. _is_alternate_work_day is dropped: tour purpose
+    # reads the day's work location from o/d_location_type == ALTERNATE_WORK,
+    # which is written above and outlives this cleanup.
     drop_cols = [
         "work_lat",
         "work_lon",
@@ -319,16 +440,23 @@ def expand_anchor_periods(
         "_d_dist_to_usual_work",
         "_o_dist_to_usual_school",
         "_d_dist_to_usual_school",
-        "_o_at_usual_work",
-        "_d_at_usual_work",
+        "_o_dist_to_day_work",
+        "_d_dist_to_day_work",
         "_o_at_usual_school",
         "_d_at_usual_school",
-        "_at_usual_work",
+        "_at_workplace",
         "_at_usual_school",
         "_work_period_start",
         "_work_period_end",
         "_school_period_start",
         "_school_period_end",
+        "_trip_touches_usual_work",
+        "_visited_usual_work",
+        "_is_alternate_work_day",
+        "_alt_work_lat",
+        "_alt_work_lon",
+        "_day_work_lat",
+        "_day_work_lon",
     ]
     linked_trips = linked_trips.drop(drop_cols)
 
@@ -432,8 +560,11 @@ def detect_anchor_based_subtours(  # noqa: C901, PLR0915
         # Get anchor location flags based on anchor type
         # Pulled outside inner loop to filter once per tour
         if anchor_type == LocationType.WORK.value:
-            o_at_anchor = tour_df["_o_is_work"].to_list()
-            d_at_anchor = tour_df["_d_is_work"].to_list()
+            # Use the day's-workplace flags so WORK_RELATED errands away from the
+            # workplace read as "away from anchor" (and become subtours), while an
+            # alternate workplace is treated as the anchor.
+            o_at_anchor = tour_df["_o_at_workplace"].to_list()
+            d_at_anchor = tour_df["_d_at_workplace"].to_list()
         elif anchor_type == LocationType.SCHOOL.value:
             o_at_anchor = tour_df["_o_is_school"].to_list()
             d_at_anchor = tour_df["_d_is_school"].to_list()

--- a/tests/test_alternate_work.py
+++ b/tests/test_alternate_work.py
@@ -1,0 +1,213 @@
+"""Tests for alternate-workplace detection and work-based subtour formation.
+
+A person's work location for a day is normally their usual workplace. When they
+never visit it and instead report WORK_RELATED activity elsewhere, that
+elsewhere is the day's workplace, and tours anchored there are work tours.
+
+Covers:
+- A day at an alternate workplace produces a WORK tour tagged ALTERNATE_WORK
+- WORK_RELATED activity away from the workplace forms a work-based subtour
+  rather than being absorbed as an intermediate stop
+"""
+
+from datetime import datetime
+
+import polars as pl
+import pytest
+
+from data_canon.codebook.days import TravelDow
+from data_canon.codebook.generic import LocationType
+from data_canon.codebook.persons import AgeCategory, Employment, Student
+from data_canon.codebook.trips import Driver, ModeType, Purpose, PurposeCategory
+from processing import link_trips
+from processing.tours.extraction import extract_tours
+
+HOME = (37.8, -122.4)
+USUAL_WORK = (37.85, -122.45)
+# Far from the usual workplace, so it cannot be mistaken for it
+ALT_WORK = (37.95, -122.55)
+# Near the usual workplace, but not at it - a work errand
+WORK_ERRAND = (37.86, -122.46)
+
+
+@pytest.fixture
+def person_and_household():
+    """One full-time worker with a usual workplace."""
+    persons = pl.DataFrame(
+        {
+            "person_id": [1],
+            "hh_id": [1],
+            "age": [AgeCategory.AGE_35_TO_44.value],
+            "employment": [Employment.EMPLOYED_FULLTIME.value],
+            "student": [Student.NONSTUDENT.value],
+            "school_type": [None],
+            "work_lat": [USUAL_WORK[0]],
+            "work_lon": [USUAL_WORK[1]],
+            "school_lat": [None],
+            "school_lon": [None],
+        }
+    )
+    households = pl.DataFrame({"hh_id": [1], "home_lat": [HOME[0]], "home_lon": [HOME[1]]})
+    return persons, households
+
+
+def _build(trips: list[dict]) -> pl.DataFrame:
+    """Turn trip dicts into an unlinked_trips frame."""
+    return pl.DataFrame(
+        {
+            "unlinked_trip_id": list(range(1, len(trips) + 1)),
+            "day_id": [1] * len(trips),
+            "person_id": [1] * len(trips),
+            "hh_id": [1] * len(trips),
+            "travel_dow": [TravelDow.WEDNESDAY.value] * len(trips),
+            "depart_time": [t["depart"] for t in trips],
+            "arrive_time": [t["arrive"] for t in trips],
+            "o_purpose_category": [t["o_cat"] for t in trips],
+            "d_purpose_category": [t["d_cat"] for t in trips],
+            "o_purpose": [t["o_purp"] for t in trips],
+            "d_purpose": [t["d_purp"] for t in trips],
+            "mode_type": [ModeType.CAR.value] * len(trips),
+            "o_lat": [t["o"][0] for t in trips],
+            "o_lon": [t["o"][1] for t in trips],
+            "d_lat": [t["d"][0] for t in trips],
+            "d_lon": [t["d"][1] for t in trips],
+            "unlinked_trip_weight": [1.0] * len(trips),
+            "distance_meters": [5000.0] * len(trips),
+            "duration_minutes": [30.0] * len(trips),
+            "num_travelers": [1] * len(trips),
+            "driver": [Driver.DRIVER.value] * len(trips),
+        }
+    )
+
+
+def _extract(persons, households, unlinked_trips):
+    """Link trips and extract tours."""
+    link_result = link_trips(
+        unlinked_trips=unlinked_trips,
+        change_mode_enum=PurposeCategory.CHANGE_MODE.value,
+        transit_mode_enums=[ModeType.TRANSIT.value],
+    )
+    linked_trips = link_result["linked_trips"].with_columns(
+        pl.lit(None).cast(pl.Int64).alias("joint_trip_id")
+    )
+    return extract_tours(
+        persons,
+        households,
+        link_result["unlinked_trips"],
+        linked_trips,
+    )
+
+
+def test_alternate_workplace_day_is_a_work_tour(person_and_household):
+    """A day worked away from the usual workplace is still a work tour.
+
+    The person never goes to their usual workplace; they spend the day at
+    another location reported as WORK_RELATED. That location is the day's
+    workplace, so the tour is WORK - not WORK_RELATED.
+    """
+    persons, households = person_and_household
+    unlinked_trips = _build(
+        [
+            {
+                "depart": datetime(2024, 1, 17, 8, 0),
+                "arrive": datetime(2024, 1, 17, 8, 45),
+                "o": HOME,
+                "d": ALT_WORK,
+                "o_cat": PurposeCategory.HOME.value,
+                "d_cat": PurposeCategory.WORK_RELATED.value,
+                "o_purp": Purpose.HOME.value,
+                "d_purp": Purpose.WORK_ACTIVITY.value,
+            },
+            {
+                "depart": datetime(2024, 1, 17, 17, 0),
+                "arrive": datetime(2024, 1, 17, 17, 45),
+                "o": ALT_WORK,
+                "d": HOME,
+                "o_cat": PurposeCategory.WORK_RELATED.value,
+                "d_cat": PurposeCategory.HOME.value,
+                "o_purp": Purpose.WORK_ACTIVITY.value,
+                "d_purp": Purpose.HOME.value,
+            },
+        ]
+    )
+
+    result = _extract(persons, households, unlinked_trips)
+    tours = result["tours"]
+    linked_trips = result["linked_trips"]
+
+    # The trip end at the day's workplace is tagged ALTERNATE_WORK. This is
+    # asserted on the linked trip, which carries the authoritative per-end
+    # classification; the tour-level d_location_type is a separate concern
+    # (see the tour aggregation coherence note).
+    assert (
+        linked_trips.filter(pl.col("d_location_type") == LocationType.ALTERNATE_WORK.value).height
+        >= 1
+    ), "The alternate-workplace trip end should be classified ALTERNATE_WORK"
+
+    assert len(tours) == 1
+    tour = tours.row(0, named=True)
+    assert tour["tour_purpose"] == PurposeCategory.WORK.value, (
+        "A tour anchored at the day's workplace should be a WORK tour, not WORK_RELATED"
+    )
+
+
+def test_work_related_errand_forms_a_subtour(person_and_household):
+    """A mid-day WORK_RELATED errand away from work is a work-based subtour.
+
+    home -> work -> errand -> work -> home. The errand is away from the
+    workplace, so it is not "at work" and the person leaving and returning
+    forms a subtour rather than an intermediate stop.
+    """
+    persons, households = person_and_household
+    unlinked_trips = _build(
+        [
+            {
+                "depart": datetime(2024, 1, 17, 8, 0),
+                "arrive": datetime(2024, 1, 17, 8, 30),
+                "o": HOME,
+                "d": USUAL_WORK,
+                "o_cat": PurposeCategory.HOME.value,
+                "d_cat": PurposeCategory.WORK.value,
+                "o_purp": Purpose.HOME.value,
+                "d_purp": Purpose.PRIMARY_WORKPLACE.value,
+            },
+            {
+                "depart": datetime(2024, 1, 17, 12, 0),
+                "arrive": datetime(2024, 1, 17, 12, 15),
+                "o": USUAL_WORK,
+                "d": WORK_ERRAND,
+                "o_cat": PurposeCategory.WORK.value,
+                "d_cat": PurposeCategory.WORK_RELATED.value,
+                "o_purp": Purpose.PRIMARY_WORKPLACE.value,
+                "d_purp": Purpose.WORK_ACTIVITY.value,
+            },
+            {
+                "depart": datetime(2024, 1, 17, 13, 30),
+                "arrive": datetime(2024, 1, 17, 13, 45),
+                "o": WORK_ERRAND,
+                "d": USUAL_WORK,
+                "o_cat": PurposeCategory.WORK_RELATED.value,
+                "d_cat": PurposeCategory.WORK.value,
+                "o_purp": Purpose.WORK_ACTIVITY.value,
+                "d_purp": Purpose.PRIMARY_WORKPLACE.value,
+            },
+            {
+                "depart": datetime(2024, 1, 17, 17, 0),
+                "arrive": datetime(2024, 1, 17, 17, 30),
+                "o": USUAL_WORK,
+                "d": HOME,
+                "o_cat": PurposeCategory.WORK.value,
+                "d_cat": PurposeCategory.HOME.value,
+                "o_purp": Purpose.PRIMARY_WORKPLACE.value,
+                "d_purp": Purpose.HOME.value,
+            },
+        ]
+    )
+
+    tours = _extract(persons, households, unlinked_trips)["tours"]
+
+    subtours = tours.filter(pl.col("subtour_num") > 0)
+    assert len(subtours) >= 1, (
+        "The WORK_RELATED errand away from the workplace should form a work-based "
+        "subtour, not be absorbed as an intermediate stop"
+    )


### PR DESCRIPTION
Extracted from `tm1.7_calibration` (`56824ab`, authored by Lisa Zorn). Part of splitting core-pipeline changes out of that branch so they get reviewed as pipeline changes rather than as CT-RAMP calibration.

**Base:** `core/tour-primary-destination`. **Last in the chain — merge `core/labeled-enum`, `core/linked-trip-fields` and `core/tour-primary-destination` first.**

## What changes

Resolves a per-person-day "work location" and uses it consistently for tour and subtour formation, fixing two related issues where `WORK_RELATED` trips were mishandled:

- Mid-day `WORK_RELATED` out-and-backs near the workplace (Work → work errand → Work) were absorbed as intermediate stops instead of forming a work-based subtour, because `WORK_RELATED` was treated as "at work".
- Days where a person worked at an **alternate location** (reported as `WORK_RELATED` rather than at their usual workplace) were not recognised as work tours.

Specifically:

- **`detection_helpers`** resolves the day's work location in `expand_anchor_periods` — the usual workplace when visited, otherwise the `WORK_RELATED` destination with the longest activity duration (an alternate workplace). One "at workplace" flag now drives both the anchor period and subtour leave/return detection.
- **`codebook/generic`** adds `LocationType.ALTERNATE_WORK` and tags alternate-workplace trip ends so the day's actual work location is visible in `o/d_location_type`.
- **`aggregation_helpers`** classifies a tour whose primary destination is `ALTERNATE_WORK` as a `WORK` tour, and uses the work threshold for its timing.

## What was deliberately left out

The original commit also deleted `_promote_work_related_to_work_for_workers` from `ctramp/format_tours.py`. That function was **added earlier on the same branch** (`8c64b4a`) and does **not exist on `develop`**, so the deletion is a no-op here — it belongs with the CT-RAMP PR.

With it omitted, **this entire core stack touches zero CT-RAMP files.**

## One comment corrected

A comment claimed `_is_alternate_work_day` was kept "used by tour purpose", but it is in `drop_cols`. The **code is correct** — the signal survives via `o/d_location_type == ALTERNATE_WORK`, which is what `aggregation_helpers` actually reads — but the comment described the opposite of what happens.

## ⚠️ Reviewer notes

Unconditional and broad. Work-anchor membership, work-period expansion, and work-based subtour detection all change for:

1. any day with a `WORK`-purpose trip end outside the distance threshold — purpose now qualifies as an anchor, where the base version was distance-only; and
2. any day with `WORK_RELATED` trips and no usual-work visit — now generates an alternate-work anchor and subtours.

`o/d_location_type` gains a **fifth** value, so any downstream mapping keyed exhaustively on `LocationType` 1–4 can now encounter an unmapped `5`. This reaches DaySim's `toadtyp`/`tdadtyp` directly.

## Verification

- `uv run pytest` → **803 passed**, matching the `develop` baseline.
- `uv run ruff check . && uv run ruff format --check .` → clean.
- Column matrix regenerated and in sync (CI gate).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
