### PR TITLE
Make tour d_location_type describe the primary destination

### DIFF
--- a/src/processing/tours/aggregation_helpers.py
+++ b/src/processing/tours/aggregation_helpers.py
@@ -270,12 +270,12 @@ def _aggregate_and_classify_tours(
             pl.col("arrive_time").max().alias("origin_arrive_time"),
             pl.col("o_lat").first(),
             pl.col("o_lon").first(),
-            # Keep fallback destination coordinates for edge cases
+            # Keep fallback destination coordinates and type for edge cases
             # (e.g., single-trip tours with no non-last trip)
             pl.col("d_lat").last().alias("_fallback_d_lat"),
             pl.col("d_lon").last().alias("_fallback_d_lon"),
             pl.col("o_location_type").first().alias("o_location_type"),
-            pl.col("d_location_type").last().alias("d_location_type"),
+            pl.col("d_location_type").last().alias("_fallback_d_location_type"),
             # Counts
             pl.col("linked_trip_id").count().alias("trip_count"),
             (pl.col("linked_trip_id").count() - 1).alias("stop_count"),
@@ -296,6 +296,7 @@ def _aggregate_and_classify_tours(
                     "tour_purpose",
                     pl.col("_primary_d_lat").alias("d_lat"),
                     pl.col("_primary_d_lon").alias("d_lon"),
+                    pl.col("_primary_d_type").alias("d_location_type"),
                 ]
             ),
             on="tour_id",
@@ -305,9 +306,14 @@ def _aggregate_and_classify_tours(
             [
                 pl.coalesce(["d_lat", "_fallback_d_lat"]).alias("d_lat"),
                 pl.coalesce(["d_lon", "_fallback_d_lon"]).alias("d_lon"),
+                # Keep d_location_type describing the same place as d_lat/d_lon:
+                # the primary destination, falling back to the last trip.
+                pl.coalesce(["d_location_type", "_fallback_d_location_type"]).alias(
+                    "d_location_type"
+                ),
             ]
         )
-        .drop(["_fallback_d_lat", "_fallback_d_lon"])
+        .drop(["_fallback_d_lat", "_fallback_d_lon", "_fallback_d_location_type"])
         .join(dest_times, on="tour_id", how="left")
     )
 

--- a/tests/test_tour_edge_cases.py
+++ b/tests/test_tour_edge_cases.py
@@ -13,6 +13,7 @@ import polars as pl
 import pytest
 
 from data_canon.codebook.days import TravelDow
+from data_canon.codebook.generic import LocationType
 from data_canon.codebook.persons import (
     AgeCategory,
     Employment,
@@ -390,6 +391,27 @@ def test_tour_destination_is_primary_destination_not_home(round_trip_tour_data):
     assert (tour["d_lat"], tour["d_lon"]) == SHOP, (
         "Tour destination should be the primary destination (the shop), not the "
         "last trip's destination (home)"
+    )
+
+
+def test_tour_destination_type_matches_destination_coords(round_trip_tour_data):
+    """d_location_type must describe the same place as d_lat/d_lon.
+
+    For home -> shop -> home the destination is the shop (OTHER). d_location_type
+    is taken from the primary destination, like d_lat/d_lon, so the two agree.
+    Previously d_location_type came from the last trip (home) while d_lat came
+    from the primary destination, so a tour zoned to the shop was labelled HOME.
+    """
+    persons, households, unlinked_trips, linked_trips = round_trip_tour_data
+
+    tour = extract_tours(persons, households, unlinked_trips, linked_trips)["tours"].row(
+        0, named=True
+    )
+
+    assert (tour["d_lat"], tour["d_lon"]) == SHOP
+    assert tour["d_location_type"] == LocationType.OTHER.value, (
+        "d_location_type should describe the primary destination (shop=OTHER), "
+        "consistent with d_lat/d_lon, not the last trip's home"
     )
 
 


### PR DESCRIPTION
## Description

Follow-up to #69. When #69 moved tour `d_lat`/`d_lon` to the **primary destination**, it left `d_location_type` coming from the **last trip**. For a home-anchored tour the last trip ends at home, so every multi-trip tour ends up with:

- `d_lat`/`d_lon` = the real destination (e.g. the shop) ✅
- `d_location_type` = **HOME** ❌

i.e. the coordinate and its type describe different places. Downstream, `add_zone_ids` derives `d_taz` from `d_lat`/`d_lon` (the shop's zone) while DaySim publishes `tdadtyp` = `d_location_type` (HOME) — a tour zoned to the shop, labelled Home.

`_primary_d_type` (the primary destination's location type) was **already computed** for distance thresholds. This assigns `d_location_type` from it and coalesces with the last-trip value as a fallback, exactly mirroring how `d_lat`/`d_lon` are already handled — so the coordinate and its type always describe the same place.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (output values change: `tours.d_location_type` / DaySim `tdadtyp`)

## Testing

- [x] All existing tests pass (810)
- [x] Added a test

`test_tour_destination_type_matches_destination_coords`: for `home -> shop -> home` the tour is now `OTHER` (the shop), consistent with `d_lat`. It **fails on develop** with `d_location_type == HOME` (`assert 1 == 4`).

## ⚠️ Reviewer note

This changes `tours.d_location_type` for essentially every multi-trip tour, and therefore DaySim's `tdadtyp`. That is the intended correction — before this, `tdadtyp` and the tour's zone disagreed. Values will move; they will now be internally consistent.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
