### PR TITLE
Add aoResults and cdapResults CT-RAMP output tables

### DIFF
--- a/src/data_canon/models/ctramp.py
+++ b/src/data_canon/models/ctramp.py
@@ -532,3 +532,31 @@ class JointTripCTRAMPModel(BaseModel):
         default=None,
         description="Walk to transit destination sub-zone (0=cannot walk to transit; 1=short-walk; 2=long-walk)",
     )
+
+
+class CDAPResultsCTRAMPModel(BaseModel):
+    """CDAP (Coordinated Daily Activity Pattern) results in CT-RAMP format.
+
+    Matches the schema of ``cdapResults.csv`` written by the CT-RAMP Java model.
+    """
+
+    HHID: int = Field(description="Unique household ID number")
+    PersonID: int = Field(description="Unique person ID number")
+    PersonNum: int = Field(ge=1, description="Person number unique to the household")
+    PersonType: int = Field(ge=1, le=8, description="Person type code (1-8)")
+    ActivityString: CTRAMPActivityPattern = Field(
+        description="Daily activity pattern (M=mandatory, N=non-mandatory, H=home)"
+    )
+    person_weight: float | None = Field(
+        default=None, ge=0, description="Survey weight for the person (not part of CT-RAMP spec)"
+    )
+
+
+class AOResultsCTRAMPModel(BaseModel):
+    """Auto Ownership results in CT-RAMP format.
+
+    Matches the schema of ``aoResults.csv`` written by the CT-RAMP Java model.
+    """
+
+    HHID: int = Field(description="Unique household ID number")
+    AO: int = Field(ge=0, description="Number of vehicles owned by the household")

--- a/src/processing/formatting/ctramp/format_ao.py
+++ b/src/processing/formatting/ctramp/format_ao.py
@@ -1,0 +1,27 @@
+"""Auto Ownership Results formatting for CT-RAMP.
+
+Produces an ``ao_results_ctramp`` table matching the schema of the
+``aoResults.csv`` file written by the CT-RAMP Java model::
+
+    HHID, AO
+
+``AO`` is the number of vehicles owned by the household (0-4+).
+"""
+
+import polars as pl
+
+
+def format_ao_results(households_ctramp: pl.DataFrame) -> pl.DataFrame:
+    """Derive aoResults from the already-formatted households table.
+
+    Args:
+        households_ctramp: Formatted CT-RAMP households table, expected to have
+            ``hh_id`` and ``autos``.
+
+    Returns:
+        DataFrame with columns ``HHID``, ``AO``.
+    """
+    return households_ctramp.select(
+        pl.col("hh_id").alias("HHID"),
+        pl.col("autos").alias("AO"),
+    )

--- a/src/processing/formatting/ctramp/format_cdap.py
+++ b/src/processing/formatting/ctramp/format_cdap.py
@@ -1,0 +1,35 @@
+"""CDAP Results formatting for CT-RAMP.
+
+Produces a ``cdap_results_ctramp`` table matching the schema of the
+``cdapResults.csv`` file written by the CT-RAMP Java model::
+
+    HHID, PersonID, PersonNum, PersonType, ActivityString
+
+``PersonType`` is an integer (1-8) and ``ActivityString`` is H/M/N.
+"""
+
+import polars as pl
+
+
+def format_cdap_results(persons_ctramp: pl.DataFrame) -> pl.DataFrame:
+    """Derive cdapResults from the already-formatted persons table.
+
+    Args:
+        persons_ctramp: Formatted CT-RAMP persons table, expected to have
+            ``hh_id``, ``person_id``, ``person_num``, ``person_type`` (int),
+            and ``activity_pattern`` (H/M/N).
+
+    Returns:
+        DataFrame with columns ``HHID``, ``PersonID``, ``PersonNum``,
+        ``PersonType`` (int), ``ActivityString`` (str).
+    """
+    cols = [
+        pl.col("hh_id").alias("HHID"),
+        pl.col("person_id").alias("PersonID"),
+        pl.col("person_num").alias("PersonNum"),
+        pl.col("person_type").cast(pl.Int32).alias("PersonType"),
+        pl.col("activity_pattern").alias("ActivityString"),
+    ]
+    if "person_weight" in persons_ctramp.columns:
+        cols.append(pl.col("person_weight"))
+    return persons_ctramp.select(cols)

--- a/src/processing/formatting/ctramp/format_ctramp.py
+++ b/src/processing/formatting/ctramp/format_ctramp.py
@@ -195,6 +195,8 @@ import polars as pl
 
 from data_canon.codebook.ctramp import CTRAMPEmploymentCategory
 from data_canon.models.ctramp import (
+    AOResultsCTRAMPModel,
+    CDAPResultsCTRAMPModel,
     HouseholdCTRAMPModel,
     IndividualTourCTRAMPModel,
     IndividualTripCTRAMPModel,
@@ -206,6 +208,8 @@ from data_canon.models.ctramp import (
 from pipeline.decoration import step
 
 from .ctramp_config import CTRAMPConfig
+from .format_ao import format_ao_results
+from .format_cdap import format_cdap_results
 from .format_households import format_households
 from .format_mandatory_location import format_mandatory_location
 from .format_persons import enrich_persons_with_person_type, format_persons
@@ -224,6 +228,8 @@ MODEL_MAP = {
     "individual_tours_ctramp": IndividualTourCTRAMPModel,
     "joint_trips_ctramp": JointTripCTRAMPModel,
     "joint_tours_ctramp": JointTourCTRAMPModel,
+    "cdap_results_ctramp": CDAPResultsCTRAMPModel,
+    "ao_results_ctramp": AOResultsCTRAMPModel,
 }
 
 
@@ -617,6 +623,11 @@ def format_ctramp(
         "joint_tours_ctramp": joint_tours_ctramp,
         "mandatory_locations_ctramp": mandatory_location_ctramp,
     }
+
+    # Derive cdapResults / aoResults from the formatted persons/households before
+    # the cleanup loop trims each table to its own model.
+    tables["cdap_results_ctramp"] = format_cdap_results(tables["persons_ctramp"])
+    tables["ao_results_ctramp"] = format_ao_results(tables["households_ctramp"])
 
     # Cleanup tables
     for table_name, df in tables.items():

--- a/tests/test_ctramp_ao_cdap.py
+++ b/tests/test_ctramp_ao_cdap.py
@@ -1,0 +1,87 @@
+"""Tests for the aoResults and cdapResults CT-RAMP output formatters.
+
+Both derive their output from an already-formatted CT-RAMP table by selecting
+and renaming columns, matching the schema of aoResults.csv / cdapResults.csv
+written by the CT-RAMP Java model.
+"""
+
+import polars as pl
+
+from data_canon.codebook.ctramp import CTRAMPActivityPattern
+from processing.formatting.ctramp.format_ao import format_ao_results
+from processing.formatting.ctramp.format_cdap import format_cdap_results
+
+
+def test_format_ao_results_maps_autos_to_ao():
+    """AoResults is HHID + AO, taken from hh_id + autos."""
+    households_ctramp = pl.DataFrame(
+        {"hh_id": [101, 102], "autos": [0, 3], "extra_col": ["x", "y"]}
+    )
+
+    result = format_ao_results(households_ctramp)
+
+    assert result.columns == ["HHID", "AO"]
+    assert result.sort("HHID").rows() == [(101, 0), (102, 3)]
+
+
+def test_format_cdap_results_schema_and_person_type_is_int():
+    """CdapResults is HHID, PersonID, PersonNum, PersonType (int), ActivityString."""
+    persons_ctramp = pl.DataFrame(
+        {
+            "hh_id": [101, 101],
+            "person_id": [10101, 10102],
+            "person_num": [1, 2],
+            "person_type": [1, 6],
+            "activity_pattern": [
+                CTRAMPActivityPattern.MANDATORY.value,
+                CTRAMPActivityPattern.HOME.value,
+            ],
+            "extra_col": ["x", "y"],
+        }
+    )
+
+    result = format_cdap_results(persons_ctramp)
+
+    assert result.columns == ["HHID", "PersonID", "PersonNum", "PersonType", "ActivityString"]
+    assert result.schema["PersonType"] == pl.Int32
+    row = result.filter(pl.col("PersonID") == 10101).row(0, named=True)
+    assert row["HHID"] == 101
+    assert row["PersonNum"] == 1
+    assert row["PersonType"] == 1
+    assert row["ActivityString"] == CTRAMPActivityPattern.MANDATORY.value
+
+
+def test_format_cdap_results_includes_person_weight_when_present():
+    """The optional survey person_weight passes through when the column exists."""
+    persons_ctramp = pl.DataFrame(
+        {
+            "hh_id": [101],
+            "person_id": [10101],
+            "person_num": [1],
+            "person_type": [1],
+            "activity_pattern": [CTRAMPActivityPattern.NON_MANDATORY.value],
+            "person_weight": [2.5],
+        }
+    )
+
+    result = format_cdap_results(persons_ctramp)
+
+    assert "person_weight" in result.columns
+    assert result["person_weight"][0] == 2.5
+
+
+def test_format_cdap_results_omits_person_weight_when_absent():
+    """No person_weight column in, none out (it is not part of the CT-RAMP spec)."""
+    persons_ctramp = pl.DataFrame(
+        {
+            "hh_id": [101],
+            "person_id": [10101],
+            "person_num": [1],
+            "person_type": [1],
+            "activity_pattern": [CTRAMPActivityPattern.HOME.value],
+        }
+    )
+
+    result = format_cdap_results(persons_ctramp)
+
+    assert "person_weight" not in result.columns


### PR DESCRIPTION
## Description

Extracted from #56 (`tm1.7_calibration`) as a self-contained additive feature, so it can be reviewed independently of the CT-RAMP core rewrite.

Two new output tables matching the CT-RAMP Java model's `aoResults.csv` and `cdapResults.csv`:

- **`ao_results_ctramp`** — `HHID`, `AO` (household vehicle count), from `households_ctramp`
- **`cdap_results_ctramp`** — `HHID`, `PersonID`, `PersonNum`, `PersonType`, `ActivityString`, from `persons_ctramp`; the survey `person_weight` passes through when present

## Why it's separable

Both derive from already-formatted tables by selecting/renaming columns, and read only fields **develop already produces** (households `autos`; persons `person_type`/`activity_pattern`, both from the existing `enrich_persons_with_person_type`). Zero dependency on the rest of #56. The derivations run before the cleanup loop trims each table to its model.

## Type of Change

- [x] New feature (non-breaking; purely additive — two new output tables)

## Testing

- [x] All existing tests pass (814)
- [x] Added tests — the feature had **no** coverage on the source branch

`tests/test_ctramp_ao_cdap.py`: AO mapping, CDAP schema + `PersonType` int cast, and the `person_weight` present/absent branches.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
