### PR TITLE
Add enrich_2023_bats step: industry_empsix and is_home_based_worker

### DIFF
--- a/projects/bats_2023/clean_bats_2023.py
+++ b/projects/bats_2023/clean_bats_2023.py
@@ -4,6 +4,7 @@ import logging
 
 import polars as pl
 
+from data_canon.codebook.ctramp import CTRAMPIndustry
 from data_canon.codebook.households import (
     IncomeBroad,
     IncomeDetailed,
@@ -11,7 +12,7 @@ from data_canon.codebook.households import (
     ResidenceRentOwn,
     ResidenceType,
 )
-from data_canon.codebook.persons import Ethnicity, Race
+from data_canon.codebook.persons import Ethnicity, Industry, Race
 from data_canon.core.labeled_enum import LabeledEnum
 from pipeline.decoration import step
 from utils.helpers import add_time_columns, expr_haversine, get_income_midpoint
@@ -322,3 +323,156 @@ def clean_2023_bats(
         )
 
     return results
+
+
+@step()
+def enrich_2023_bats(households: pl.DataFrame, persons: pl.DataFrame) -> dict[str, pl.DataFrame]:
+    """Derive BATS-2023-specific enrichment columns on the persons table.
+
+    Derives:
+    - ``industry_empsix``: six-category NAICS-based employment sector (CT-RAMP
+      empsix) from the raw ``industry`` integer code, with a keyword-matching
+      fallback on ``industry_other`` free-text.  Follows ``INDUSTRY_RECODE`` /
+      ``INDUSTRY_OTHER_TERM_RECODE`` from the reference notebook:
+      https://github.com/BayAreaMetro/travel-model-one/blob/b759d9992745097c7f391273551f986809dc0907/utilities/telecommute/estimate_WFH_from_BATS2023.ipynb
+    - ``is_home_based_worker``: True when a person is employed and their reported
+      work location (work_lat/work_lon) matches their household home location
+      (home_lat/home_lon) exactly.
+
+    This step must run after ``imputation`` and before ``format_ctramp``.
+    """
+    logger.info("Deriving industry_empsix for BATS 2023 persons")
+
+    industry_to_empsix = {
+        Industry.AGRICULTURE.value: CTRAMPIndustry.AGREMPN,
+        Industry.MINING.value: CTRAMPIndustry.AGREMPN,
+        Industry.UTILITIES.value: CTRAMPIndustry.MWTEMPN,
+        Industry.CONSTRUCTION.value: CTRAMPIndustry.OTHEMPN,
+        Industry.MANUFACTURING.value: CTRAMPIndustry.MWTEMPN,
+        Industry.WHOLESALE_TRADE.value: CTRAMPIndustry.MWTEMPN,
+        Industry.RETAIL_TRADE.value: CTRAMPIndustry.RETEMPN,
+        Industry.TRANSPORTATION.value: CTRAMPIndustry.MWTEMPN,
+        Industry.INFORMATION.value: CTRAMPIndustry.OTHEMPN,
+        Industry.FINANCE_AND_INSURANCE.value: CTRAMPIndustry.FPSEMPN,
+        Industry.REALESTATE.value: CTRAMPIndustry.FPSEMPN,
+        Industry.PROFESSIONAL.value: CTRAMPIndustry.FPSEMPN,
+        Industry.MANAGEMENT.value: CTRAMPIndustry.FPSEMPN,
+        Industry.ADMINISTRATIVE.value: CTRAMPIndustry.FPSEMPN,
+        Industry.EDUCATIONAL.value: CTRAMPIndustry.HEREMPN,
+        Industry.HEALTH_AND_SOCIAL.value: CTRAMPIndustry.HEREMPN,
+        Industry.ARTS_AND_RECREATION.value: CTRAMPIndustry.HEREMPN,
+        Industry.ACCOMMODATION.value: CTRAMPIndustry.HEREMPN,
+        Industry.OTHER.value: CTRAMPIndustry.OTHEMPN,
+        Industry.PUBLIC_ADMINISTRATION.value: CTRAMPIndustry.OTHEMPN,
+    }
+
+    # Primary recode: industry integer → empsix
+    # industry 997 (Other, please specify) and 995 (Missing) → null (handled below)
+    if "industry" in persons.columns:
+        persons = persons.with_columns(
+            pl.col("industry")
+            .replace_strict(
+                {k: v.value for k, v in industry_to_empsix.items()},
+                default=None,
+            )
+            .alias("industry_empsix")
+        )
+    else:
+        logger.warning("'industry' column not found; industry_empsix will be null for all persons")
+        persons = persons.with_columns(pl.lit(None).cast(pl.String).alias("industry_empsix"))
+
+    # Secondary fallback: keyword matching on industry_other free-text
+    # Only fills rows still null after the primary recode.
+    if "industry_other" in persons.columns:
+        industry_other_term_recode = {
+            # FPSEMPN: Financial and professional services
+            "technology": CTRAMPIndustry.FPSEMPN,
+            "biotechnology": CTRAMPIndustry.FPSEMPN,
+            "biotech": CTRAMPIndustry.FPSEMPN,
+            "biomedical": CTRAMPIndustry.FPSEMPN,
+            "tech": CTRAMPIndustry.FPSEMPN,
+            "software": CTRAMPIndustry.FPSEMPN,
+            "security": CTRAMPIndustry.FPSEMPN,
+            "legal": CTRAMPIndustry.FPSEMPN,
+            "law": CTRAMPIndustry.FPSEMPN,
+            "attorney": CTRAMPIndustry.FPSEMPN,
+            "marketing": CTRAMPIndustry.FPSEMPN,
+            # OTHEMPN: Other employment
+            "government": CTRAMPIndustry.OTHEMPN,
+            "judicial": CTRAMPIndustry.OTHEMPN,
+            "national park service": CTRAMPIndustry.OTHEMPN,
+            "law enforcement": CTRAMPIndustry.OTHEMPN,
+            "military": CTRAMPIndustry.OTHEMPN,
+            "library": CTRAMPIndustry.OTHEMPN,
+            # MWTEMPN: Manufacturing, wholesale and transportation
+            "automotive": CTRAMPIndustry.MWTEMPN,
+            # HEREMPN: Health, educational and recreational services
+            "nonprofit": CTRAMPIndustry.HEREMPN,
+            "non-profit": CTRAMPIndustry.HEREMPN,
+            "non profit": CTRAMPIndustry.HEREMPN,
+            "philanthropy": CTRAMPIndustry.HEREMPN,
+            "childcare": CTRAMPIndustry.HEREMPN,
+            "health": CTRAMPIndustry.HEREMPN,
+            "fitness": CTRAMPIndustry.HEREMPN,
+            "school": CTRAMPIndustry.HEREMPN,
+            "hospitality": CTRAMPIndustry.HEREMPN,
+            "hotel": CTRAMPIndustry.HEREMPN,
+            # RETEMPN: Retail trade
+            "e-commerce": CTRAMPIndustry.RETEMPN,
+            "ecommerce": CTRAMPIndustry.RETEMPN,
+        }
+        persons = persons.with_columns(
+            pl.col("industry_other")
+            .str.to_lowercase()
+            .str.strip_chars()
+            .alias("_industry_other_norm")
+        )
+        for term, sector in industry_other_term_recode.items():
+            persons = persons.with_columns(
+                pl.when(
+                    pl.col("industry_empsix").is_null()
+                    & pl.col("_industry_other_norm").str.contains(term, literal=True)
+                )
+                .then(pl.lit(sector.value))
+                .otherwise(pl.col("industry_empsix"))
+                .alias("industry_empsix")
+            )
+        persons = persons.drop("_industry_other_norm")
+
+    n_resolved = persons["industry_empsix"].drop_nulls().len()
+    n_null = persons["industry_empsix"].null_count()
+    logger.info(
+        "industry_empsix: %d resolved, %d still null "
+        "(no industry reported or unmatched industry_other)",
+        n_resolved,
+        n_null,
+    )
+
+    # Derive is_home_based_worker: employed person whose work lat/lon == home lat/lon
+    if all(c in persons.columns for c in ("work_lat", "work_lon")) and all(
+        c in households.columns for c in ("hh_id", "home_lat", "home_lon")
+    ):
+        persons = (
+            persons.join(
+                households.select("hh_id", "home_lat", "home_lon"),
+                on="hh_id",
+                how="left",
+            )
+            .with_columns(
+                (
+                    pl.col("work_lat").is_not_null()
+                    & pl.col("work_lon").is_not_null()
+                    & (pl.col("work_lat") == pl.col("home_lat"))
+                    & (pl.col("work_lon") == pl.col("home_lon"))
+                ).alias("is_home_based_worker")
+            )
+            .drop("home_lat", "home_lon")
+        )
+        n_hbw = persons["is_home_based_worker"].sum()
+        logger.info("is_home_based_worker: %d persons identified", n_hbw)
+    else:
+        logger.warning(
+            "work_lat/work_lon or home_lat/home_lon not available; skipping is_home_based_worker"
+        )
+
+    return {"persons": persons}

--- a/projects/bats_2023/run.py
+++ b/projects/bats_2023/run.py
@@ -7,7 +7,7 @@ import shutil
 from pathlib import Path
 
 import polars as pl
-from clean_bats_2023 import clean_2023_bats
+from clean_bats_2023 import clean_2023_bats, enrich_2023_bats
 from dotenv import load_dotenv
 
 from data_canon.models import (
@@ -99,6 +99,7 @@ processing_steps = [
     detect_joint_trips,
     imputation,
     extract_tours,
+    enrich_2023_bats,
     format_ctramp,
     format_daysim,
     write_data,

--- a/src/data_canon/codebook/ctramp.py
+++ b/src/data_canon/codebook/ctramp.py
@@ -25,6 +25,17 @@ class CTRAMPStudentCategory(StrEnum):
     NOT_STUDENT = "Not a student"
 
 
+class CTRAMPIndustry(StrEnum):
+    """Six-category employment sector classification (NAICS-based)."""
+
+    RETEMPN = "RETEMPN"  # Retail trade
+    FPSEMPN = "FPSEMPN"  # Financial and professional services
+    HEREMPN = "HEREMPN"  # Health, educational and recreational services
+    AGREMPN = "AGREMPN"  # Agricultural and natural resources
+    MWTEMPN = "MWTEMPN"  # Manufacturing, wholesale trade and transportation
+    OTHEMPN = "OTHEMPN"  # Other employment
+
+
 class FreeParkingChoice(LabeledEnum):
     """Enumeration for free parking choice categories."""
 

--- a/src/data_canon/models/ctramp.py
+++ b/src/data_canon/models/ctramp.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel, Field, field_validator
 from data_canon.codebook.ctramp import (
     CTRAMPActivityPattern,
     CTRAMPEmploymentCategory,
+    CTRAMPIndustry,
     CTRAMPModeType,
     CTRAMPPersonType,
     CTRAMPPurpose,
@@ -155,6 +156,10 @@ class PersonCTRAMPModel(BaseModel):
     inmf_choice: int = Field(ge=0, le=96, description="Individual non-mandatory tour frequency")
     wfh_choice: WFHChoice = Field(
         description="Works from home choice (0=non-worker or workers who don't work from home, 1=workers who work from home) - Added in TM1.6",
+    )
+    industry_empsix: CTRAMPIndustry | None = Field(
+        default=None,
+        description="Six-category NAICS-based employment sector (empsix); derived upstream by enrich_2023_bats",
     )
 
     # NOTE: Not part of CT-RAMP spec; for survey - model comparative analysis.

--- a/src/processing/formatting/ctramp/format_persons.py
+++ b/src/processing/formatting/ctramp/format_persons.py
@@ -514,6 +514,14 @@ def format_persons(
 
     # Note: employment_category was already computed before person_type derivation
 
+    # industry_empsix is derived upstream by enrich_2023_bats and passed through as-is.
+    # For pipelines that do not run that step, add a null column so downstream
+    # validation and output schemas remain consistent.
+    if "industry_empsix" not in persons_ctramp.columns:
+        persons_ctramp = persons_ctramp.with_columns(
+            pl.lit(None).cast(pl.String).alias("industry_empsix")
+        )
+
     # Note: value_of_time is model output, not survey data
     # If it exists in the input, keep it; otherwise it will be null
     if "value_of_time" not in persons_ctramp.columns:

--- a/tests/test_enrich_2023_bats.py
+++ b/tests/test_enrich_2023_bats.py
@@ -1,0 +1,94 @@
+"""Tests for the BATS-2023 enrich step (industry_empsix + is_home_based_worker).
+
+`enrich_2023_bats` lives in the bats_2023 project scripts, so the project
+directory is added to sys.path to import it.
+"""
+
+import sys
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+_PROJECT_DIR = Path(__file__).resolve().parents[1] / "projects" / "bats_2023"
+if str(_PROJECT_DIR) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_DIR))
+
+from clean_bats_2023 import enrich_2023_bats  # noqa: E402
+
+from data_canon.codebook.ctramp import CTRAMPIndustry  # noqa: E402
+from data_canon.codebook.persons import Industry  # noqa: E402
+
+
+def _run(persons: pl.DataFrame, households: pl.DataFrame) -> pl.DataFrame:
+    """Call the step and return the enriched persons frame."""
+    return enrich_2023_bats(households=households, persons=persons)["persons"]
+
+
+@pytest.fixture
+def households() -> pl.DataFrame:
+    """A single household whose home is at (37.8, -122.4)."""
+    return pl.DataFrame({"hh_id": [10], "home_lat": [37.8], "home_lon": [-122.4]})
+
+
+def test_industry_recoded_to_empsix(households):
+    """The raw industry code maps to the six-category empsix sector."""
+    persons = pl.DataFrame(
+        {
+            "person_id": [1, 2, 3],
+            "hh_id": [10, 10, 10],
+            "industry": [
+                Industry.RETAIL_TRADE.value,
+                Industry.HEALTH_AND_SOCIAL.value,
+                Industry.FINANCE_AND_INSURANCE.value,
+            ],
+            "industry_other": pl.Series([None, None, None], dtype=pl.String),
+            "work_lat": [None, None, None],
+            "work_lon": [None, None, None],
+        }
+    )
+
+    out = _run(persons, households)
+
+    assert out.sort("person_id")["industry_empsix"].to_list() == [
+        CTRAMPIndustry.RETEMPN.value,
+        CTRAMPIndustry.HEREMPN.value,
+        CTRAMPIndustry.FPSEMPN.value,
+    ]
+
+
+def test_industry_other_keyword_fallback(households):
+    """When industry is unresolved, a keyword in industry_other fills empsix."""
+    persons = pl.DataFrame(
+        {
+            "person_id": [1],
+            "hh_id": [10],
+            # 995 (Missing) does not map, so the free-text fallback applies
+            "industry": [995],
+            "industry_other": pl.Series(["Software engineering"], dtype=pl.String),
+            "work_lat": [None],
+            "work_lon": [None],
+        }
+    )
+
+    out = _run(persons, households)
+
+    assert out["industry_empsix"][0] == CTRAMPIndustry.FPSEMPN.value
+
+
+def test_is_home_based_worker_when_work_equals_home(households):
+    """A worker whose work location equals home is flagged home-based."""
+    persons = pl.DataFrame(
+        {
+            "person_id": [1, 2],
+            "hh_id": [10, 10],
+            "industry": [Industry.RETAIL_TRADE.value, Industry.RETAIL_TRADE.value],
+            "industry_other": pl.Series([None, None], dtype=pl.String),
+            "work_lat": [37.8, 37.85],  # person 1 works at home, person 2 elsewhere
+            "work_lon": [-122.4, -122.45],
+        }
+    )
+
+    out = _run(persons, households).sort("person_id")
+
+    assert out["is_home_based_worker"].to_list() == [True, False]


### PR DESCRIPTION
## Description

Extracted from #56 (`tm1.7_calibration`) as a self-contained upstream feature, reviewable independently of the CT-RAMP core rewrite.

New BATS-2023 enrichment step deriving two person columns:
- **`industry_empsix`** — six-category NAICS-based employment sector (CT-RAMP `empsix`) from the raw `industry` code, with a keyword fallback on `industry_other` free-text.
- **`is_home_based_worker`** — employed person whose work lat/lon equals home lat/lon.

## Why it's separable

`format_persons` consumes `industry_empsix` behind a **null guard** (adds a null column when the enrich step didn't run), so `format_ctramp` produces a consistent schema with or without it. The step reads only canonical `industry`/`industry_other`/`work_lat`/`home_lat` (all on develop). Registered in `run.py`; **activation is a config choice** — it is not in develop's default `steps`, so default pipeline behavior is unchanged.

## Type of Change

- [x] New feature (additive; opt-in via config)

## Testing

- [x] All existing tests pass (813)
- [x] Added tests — the source branch had **none** for this step

`tests/test_enrich_2023_bats.py`: industry→empsix recode, `industry_other` keyword fallback, and the home-based-worker flag.

## Note

The `industry_other` free-text handling assumes a String column; if a survey delivers it as all-null (Null dtype) the `.str` ops would raise. Faithful to the source branch — flagging as a possible follow-up hardening, not changed here.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
