### PR TITLE
Make residence_rent_own/residence_type extraction deterministic

### DIFF
--- a/projects/bats_2023/clean_bats_2023.py
+++ b/projects/bats_2023/clean_bats_2023.py
@@ -178,11 +178,15 @@ def clean_2023_bats(
             )
         )
         .mode()
+        # mode() can return several tied values in arbitrary order; sort so the
+        # tie-break is deterministic (smallest code) rather than hash-dependent.
+        .sort()
         .first()
         .fill_null(995),
         pl.col("residence_type")
         .filter(pl.col("residence_type") != ResidenceType.MISSING.value)
         .mode()
+        .sort()
         .first()
         .fill_null(995),
     )


### PR DESCRIPTION
## Description

Extracted from #56 (`tm1.7_calibration`) as a standalone bugfix.

When several household members report conflicting `residence_rent_own` or `residence_type` values, `mode()` returns the tied values in arbitrary (hash-dependent) order, so `.first()` could pick a different code from run to run. Sorting the modes before `.first()` makes ties resolve deterministically to the smallest code.

## Type of Change

- [x] Bug fix (non-breaking; only affects tied inputs, whose output is now stable)

## Testing

- [x] All existing tests pass (810)
- [ ] No dedicated test added

The fix is a 2-line determinism guard inline in `clean_2023_bats`'s aggregation; a focused test would require constructing the step's full multi-table inputs, disproportionate to the change (the source branch had no test for it either). The mechanism — `.sort().first()` on `.mode()` — is self-evidently the fix.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
