### PR TITLE
Derive industry_empsix in the CT-RAMP formatter from canonical industry

### DIFF
--- a/src/data_canon/codebook/ctramp.py
+++ b/src/data_canon/codebook/ctramp.py
@@ -25,6 +25,17 @@ class CTRAMPStudentCategory(StrEnum):
     NOT_STUDENT = "Not a student"
 
 
+class CTRAMPIndustry(StrEnum):
+    """Six-category employment sector classification (empsix), used by MTC travel models."""
+
+    RETEMPN = "RETEMPN"  # Retail trade
+    FPSEMPN = "FPSEMPN"  # Financial and professional services
+    HEREMPN = "HEREMPN"  # Health, educational and recreational services
+    AGREMPN = "AGREMPN"  # Agricultural and natural resources
+    MWTEMPN = "MWTEMPN"  # Manufacturing, wholesale trade and transportation
+    OTHEMPN = "OTHEMPN"  # Other employment
+
+
 class FreeParkingChoice(LabeledEnum):
     """Enumeration for free parking choice categories."""
 

--- a/src/data_canon/models/ctramp.py
+++ b/src/data_canon/models/ctramp.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel, Field, field_validator
 from data_canon.codebook.ctramp import (
     CTRAMPActivityPattern,
     CTRAMPEmploymentCategory,
+    CTRAMPIndustry,
     CTRAMPModeType,
     CTRAMPPersonType,
     CTRAMPPurpose,
@@ -155,6 +156,10 @@ class PersonCTRAMPModel(BaseModel):
     inmf_choice: int = Field(ge=0, le=96, description="Individual non-mandatory tour frequency")
     wfh_choice: WFHChoice = Field(
         description="Works from home choice (0=non-worker or workers who don't work from home, 1=workers who work from home) - Added in TM1.6",
+    )
+    industry_empsix: CTRAMPIndustry | None = Field(
+        default=None,
+        description="Six-category employment sector (empsix), derived from the canonical industry code",
     )
 
     # NOTE: Not part of CT-RAMP spec; for survey - model comparative analysis.

--- a/src/processing/formatting/ctramp/format_persons.py
+++ b/src/processing/formatting/ctramp/format_persons.py
@@ -42,6 +42,7 @@ from .ctramp_config import CTRAMPConfig
 from .mappings import (
     EMPLOYMENT_TO_CTRAMP,
     GENDER_MAP,
+    add_industry_empsix,
     ctramp_person_type_expression,
     ctramp_student_category_expression,
     log_person_type_warnings,
@@ -513,6 +514,14 @@ def format_persons(
     )
 
     # Note: employment_category was already computed before person_type derivation
+
+    # Derive industry_empsix (CT-RAMP empsix employment sector) from the canonical
+    # industry code, filling from free-text industry_other where available.
+    persons_ctramp = persons_ctramp.join(
+        add_industry_empsix(persons_canonical).select(["person_id", "industry_empsix"]),
+        on="person_id",
+        how="left",
+    )
 
     # Note: value_of_time is model output, not survey data
     # If it exists in the input, keep it; otherwise it will be null

--- a/src/processing/formatting/ctramp/mappings.py
+++ b/src/processing/formatting/ctramp/mappings.py
@@ -11,6 +11,7 @@ import polars as pl
 from data_canon.codebook.ctramp import (
     CTRAMPEmploymentCategory,
     CTRAMPGender,
+    CTRAMPIndustry,
     CTRAMPModeType,
     CTRAMPPersonType,
     CTRAMPPurpose,
@@ -20,6 +21,7 @@ from data_canon.codebook.persons import (
     AgeCategory,
     Employment,
     Gender,
+    Industry,
     SchoolType,
     Student,
 )
@@ -1174,3 +1176,115 @@ _duplicate_check = len(PURPOSECATEGORY_TO_JTF_GROUP)
 if _duplicate_check != len(_all_purpose_categories):
     msg = "Duplicate keys found in PURPOSECATEGORY_TO_JTF_GROUP mapping"
     raise ValueError(msg)
+
+
+# Industry (NAICS) -> empsix employment sector -----------------------------------
+# empsix is the six-category employment classification used by MTC travel models.
+INDUSTRY_TO_EMPSIX = {
+    Industry.AGRICULTURE.value: CTRAMPIndustry.AGREMPN.value,
+    Industry.MINING.value: CTRAMPIndustry.AGREMPN.value,
+    Industry.UTILITIES.value: CTRAMPIndustry.MWTEMPN.value,
+    Industry.CONSTRUCTION.value: CTRAMPIndustry.OTHEMPN.value,
+    Industry.MANUFACTURING.value: CTRAMPIndustry.MWTEMPN.value,
+    Industry.WHOLESALE_TRADE.value: CTRAMPIndustry.MWTEMPN.value,
+    Industry.RETAIL_TRADE.value: CTRAMPIndustry.RETEMPN.value,
+    Industry.TRANSPORTATION.value: CTRAMPIndustry.MWTEMPN.value,
+    Industry.INFORMATION.value: CTRAMPIndustry.OTHEMPN.value,
+    Industry.FINANCE_AND_INSURANCE.value: CTRAMPIndustry.FPSEMPN.value,
+    Industry.REALESTATE.value: CTRAMPIndustry.FPSEMPN.value,
+    Industry.PROFESSIONAL.value: CTRAMPIndustry.FPSEMPN.value,
+    Industry.MANAGEMENT.value: CTRAMPIndustry.FPSEMPN.value,
+    Industry.ADMINISTRATIVE.value: CTRAMPIndustry.FPSEMPN.value,
+    Industry.EDUCATIONAL.value: CTRAMPIndustry.HEREMPN.value,
+    Industry.HEALTH_AND_SOCIAL.value: CTRAMPIndustry.HEREMPN.value,
+    Industry.ARTS_AND_RECREATION.value: CTRAMPIndustry.HEREMPN.value,
+    Industry.ACCOMMODATION.value: CTRAMPIndustry.HEREMPN.value,
+    Industry.OTHER.value: CTRAMPIndustry.OTHEMPN.value,
+    Industry.PUBLIC_ADMINISTRATION.value: CTRAMPIndustry.OTHEMPN.value,
+}
+
+# Keyword fallback for the free-text "Other, please specify" industry response.
+# Only used to fill empsix that the structured `industry` code left null.
+INDUSTRY_OTHER_KEYWORD_TO_EMPSIX = {
+    # Financial and professional services
+    "technology": CTRAMPIndustry.FPSEMPN.value,
+    "biotechnology": CTRAMPIndustry.FPSEMPN.value,
+    "biotech": CTRAMPIndustry.FPSEMPN.value,
+    "biomedical": CTRAMPIndustry.FPSEMPN.value,
+    "tech": CTRAMPIndustry.FPSEMPN.value,
+    "software": CTRAMPIndustry.FPSEMPN.value,
+    "security": CTRAMPIndustry.FPSEMPN.value,
+    "legal": CTRAMPIndustry.FPSEMPN.value,
+    "law": CTRAMPIndustry.FPSEMPN.value,
+    "attorney": CTRAMPIndustry.FPSEMPN.value,
+    "marketing": CTRAMPIndustry.FPSEMPN.value,
+    # Other employment
+    "government": CTRAMPIndustry.OTHEMPN.value,
+    "judicial": CTRAMPIndustry.OTHEMPN.value,
+    "national park service": CTRAMPIndustry.OTHEMPN.value,
+    "law enforcement": CTRAMPIndustry.OTHEMPN.value,
+    "military": CTRAMPIndustry.OTHEMPN.value,
+    "library": CTRAMPIndustry.OTHEMPN.value,
+    # Manufacturing, wholesale and transportation
+    "automotive": CTRAMPIndustry.MWTEMPN.value,
+    # Health, educational and recreational services
+    "nonprofit": CTRAMPIndustry.HEREMPN.value,
+    "non-profit": CTRAMPIndustry.HEREMPN.value,
+    "non profit": CTRAMPIndustry.HEREMPN.value,
+    "philanthropy": CTRAMPIndustry.HEREMPN.value,
+    "childcare": CTRAMPIndustry.HEREMPN.value,
+    "health": CTRAMPIndustry.HEREMPN.value,
+    "fitness": CTRAMPIndustry.HEREMPN.value,
+    "school": CTRAMPIndustry.HEREMPN.value,
+    "hospitality": CTRAMPIndustry.HEREMPN.value,
+    "hotel": CTRAMPIndustry.HEREMPN.value,
+    # Retail trade
+    "e-commerce": CTRAMPIndustry.RETEMPN.value,
+    "ecommerce": CTRAMPIndustry.RETEMPN.value,
+}
+
+
+def add_industry_empsix(persons: pl.DataFrame) -> pl.DataFrame:
+    """Add an `industry_empsix` column derived from canonical `industry`.
+
+    Uses the structured NAICS `industry` code first, then fills any remaining
+    nulls from keyword matches in the free-text `industry_other` when that column
+    is present. Both inputs are read from the canonical persons frame; nothing is
+    required upstream.
+
+    Args:
+        persons: Canonical persons frame (must have `industry`; `industry_other`
+            is used when present).
+
+    Returns:
+        persons with an added `industry_empsix` column.
+    """
+    if "industry" not in persons.columns:
+        logger.warning("'industry' column not found; industry_empsix will be null for all persons")
+        return persons.with_columns(pl.lit(None).cast(pl.String).alias("industry_empsix"))
+
+    persons = persons.with_columns(
+        pl.col("industry").replace_strict(INDUSTRY_TO_EMPSIX, default=None).alias("industry_empsix")
+    )
+
+    if "industry_other" in persons.columns:
+        # Fill nulls from the free-text response. Materialise industry_empsix each
+        # iteration so pl.col("industry_empsix") stays a cheap column reference;
+        # accumulating it into a Python expression instead would build an
+        # exponentially large expression tree.
+        persons = persons.with_columns(
+            pl.col("industry_other").str.to_lowercase().str.strip_chars().alias("_industry_other")
+        )
+        for term, sector in INDUSTRY_OTHER_KEYWORD_TO_EMPSIX.items():
+            persons = persons.with_columns(
+                pl.when(
+                    pl.col("industry_empsix").is_null()
+                    & pl.col("_industry_other").str.contains(term, literal=True)
+                )
+                .then(pl.lit(sector))
+                .otherwise(pl.col("industry_empsix"))
+                .alias("industry_empsix")
+            )
+        persons = persons.drop("_industry_other")
+
+    return persons

--- a/tests/test_ctramp_industry_empsix.py
+++ b/tests/test_ctramp_industry_empsix.py
@@ -1,0 +1,73 @@
+"""Tests for industry_empsix derivation in the CT-RAMP formatter.
+
+industry_empsix (the six-category empsix employment sector) is derived in the
+CT-RAMP formatter from the canonical `industry` code, with a keyword fallback on
+the free-text `industry_other`. It is not a canonical field and is not derived
+in project cleaning steps.
+"""
+
+import polars as pl
+
+from data_canon.codebook.ctramp import CTRAMPIndustry
+from data_canon.codebook.persons import Industry
+from processing.formatting.ctramp.mappings import add_industry_empsix
+
+
+def test_structured_industry_maps_to_empsix():
+    """Each structured NAICS industry code maps to its empsix sector."""
+    persons = pl.DataFrame(
+        {
+            "person_id": [1, 2, 3],
+            "industry": [
+                Industry.RETAIL_TRADE.value,
+                Industry.HEALTH_AND_SOCIAL.value,
+                Industry.FINANCE_AND_INSURANCE.value,
+            ],
+        }
+    )
+
+    out = add_industry_empsix(persons).sort("person_id")
+
+    assert out["industry_empsix"].to_list() == [
+        CTRAMPIndustry.RETEMPN.value,
+        CTRAMPIndustry.HEREMPN.value,
+        CTRAMPIndustry.FPSEMPN.value,
+    ]
+
+
+def test_industry_other_fills_only_unresolved_rows():
+    """The free-text fallback fills empsix only where the structured code did not."""
+    persons = pl.DataFrame(
+        {
+            "person_id": [1, 2],
+            # 995 (Missing) has no structured mapping -> falls back to free-text
+            "industry": [Industry.RETAIL_TRADE.value, 995],
+            "industry_other": pl.Series([None, "Software startup"], dtype=pl.String),
+        }
+    )
+
+    out = add_industry_empsix(persons).sort("person_id")
+
+    assert out["industry_empsix"].to_list() == [
+        CTRAMPIndustry.RETEMPN.value,  # structured mapping wins
+        CTRAMPIndustry.FPSEMPN.value,  # "software" keyword fallback
+    ]
+
+
+def test_unresolved_industry_is_null_without_free_text():
+    """With no industry_other column, unmapped codes stay null (no fallback)."""
+    persons = pl.DataFrame({"person_id": [1], "industry": [995]})
+
+    out = add_industry_empsix(persons)
+
+    assert out["industry_empsix"].to_list() == [None]
+
+
+def test_missing_industry_column_yields_null_column():
+    """When industry is absent entirely, a null industry_empsix column is added."""
+    persons = pl.DataFrame({"person_id": [1, 2]})
+
+    out = add_industry_empsix(persons)
+
+    assert "industry_empsix" in out.columns
+    assert out["industry_empsix"].null_count() == 2


### PR DESCRIPTION
## Description

Reworks #74 (now closed) in response to review: the `industry → empsix` mapping is **CT-RAMP formatting, not data cleaning**, so it belongs in the formatter — not front-loaded into a `bats_2023` project step.

- **`mappings.py`**: `INDUSTRY_TO_EMPSIX` (structured NAICS → empsix) + a keyword-fallback map for free-text `industry_other`, and `add_industry_empsix()` applying both. Reads canonical `industry` (and optional `industry_other`) directly — any CT-RAMP run gets it with **no upstream step**.
- **`format_persons`**: derives `industry_empsix` via `add_industry_empsix`; no project passthrough column.
- `CTRAMPIndustry` enum + optional `industry_empsix` field on `PersonCTRAMPModel`.

## What changed from #74 (per review comments)

1. **Provenance / "single-streamed to CT-RAMP is a shame":** canonical `industry` is NAICS survey data; empsix is an MTC travel-model aggregation, so the mapping is genuinely CT-RAMP formatting. It now lives in the formatter, reusable and not buried in project glue. `clean_bats_2023.py` and `run.py` are **untouched**.
2. **Dropped `is_home_based_worker`** — it was produced but consumed nowhere (dead code). It can be added to *canonical* data if a real consumer appears.
3. **Lint:** the test imports the formatter mapping directly (`src`), so there is **no `sys.path` hack and no `# noqa`**. No pyproject changes.

## Not in scope (separate follow-ups)

- **Canonicalize `occupation`** — it's survey data used by imputation but has no `PersonModel` field (a shadow column). Worth promoting to canonical, separately.
- The keyword fallback reads `industry_other`, itself a non-canonical shadow column (guarded when absent). Promoting it to canonical is a candidate for the same occupation follow-up.

## Type of Change

- [x] Code refactoring (moves existing behavior to the correct layer)
- [x] New feature (empsix now derived for any CT-RAMP run)

## Testing

- [x] All existing tests pass (818)
- [x] Added tests: structured mapping, free-text fallback filling only unresolved rows, null-when-unmapped, missing-column guard.

Note: the keyword fallback materialises `industry_empsix` each iteration on purpose — accumulating it into a single Polars expression builds an exponential expression tree (a bug caught during this rework).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
