### PR TITLE
Give at-work subtours a real direction; retire TourDirection.SUBTOUR

### DIFF
--- a/src/data_canon/codebook/tours.py
+++ b/src/data_canon/codebook/tours.py
@@ -43,11 +43,18 @@ class TourCategory(LabeledEnum):
 
 
 class TourDirection(LabeledEnum):
-    """Half-tour classification."""
+    """Half-tour classification.
+
+    Every tour has exactly two halves relative to its own anchor and primary
+    destination, at-work subtours included. Subtour *membership* is a property
+    of the tour (``parent_tour_id`` / ``subtour_num`` / ``tour_type``), not a
+    direction, so it is deliberately not represented here: encoding it as a
+    third direction discarded the real direction that DaySim (``half``) and
+    CT-RAMP (``inbound``) both require.
+    """
 
     OUTBOUND = (1, "Outbound half-tour")
     INBOUND = (2, "Inbound half-tour")
-    SUBTOUR = (3, "Subtour")
 
 
 class TourDataQuality(LabeledEnum):

--- a/src/processing/formatting/ctramp/format_tours.py
+++ b/src/processing/formatting/ctramp/format_tours.py
@@ -533,10 +533,6 @@ def format_joint_tour(
                     )
                     .clip(lower_bound=0)
                     .alias("num_ib_stops"),
-                    pl.when(pl.col("tour_direction") == TourDirection.SUBTOUR.value)
-                    .then(1)
-                    .sum()
-                    .alias("num_subtour_stops"),
                 ]
             )
         )
@@ -547,7 +543,6 @@ def format_joint_tour(
             [
                 pl.col("num_ob_stops").fill_null(0),
                 pl.col("num_ib_stops").fill_null(0),
-                pl.col("num_subtour_stops").fill_null(0),
             ]
         )
     else:
@@ -556,7 +551,6 @@ def format_joint_tour(
                 pl.lit(None).cast(pl.Int64).alias("num_travelers"),
                 pl.lit(0).alias("num_ob_stops"),
                 pl.lit(0).alias("num_ib_stops"),
-                pl.lit(0).alias("num_subtour_stops"),
             ]
         )
 

--- a/src/processing/formatting/ctramp/format_trips.py
+++ b/src/processing/formatting/ctramp/format_trips.py
@@ -100,11 +100,9 @@ def format_individual_trip(
     # Map tour_direction enum to string for easier handling
     individual_trips = (
         individual_trips.with_columns(
-            pl.when(pl.col("tour_direction") == TourDirection.OUTBOUND.value)
-            .then(pl.lit("outbound"))
-            .when(pl.col("tour_direction") == TourDirection.INBOUND.value)
+            pl.when(pl.col("tour_direction") == TourDirection.INBOUND.value)
             .then(pl.lit("inbound"))
-            .otherwise(pl.lit("subtour"))
+            .otherwise(pl.lit("outbound"))
             .alias("tour_direction_str")
         )
         .sort(["tour_id", "tour_direction_str", "depart_time"])

--- a/src/processing/formatting/daysim/format_tours.py
+++ b/src/processing/formatting/daysim/format_tours.py
@@ -7,7 +7,7 @@ import polars as pl
 from data_canon.codebook.tours import TourDirection, TourType
 from data_canon.codebook.trips import ModeType
 
-from .mappings import PURPOSE_MAP, determine_tour_mode
+from .mappings import PURPOSE_MAP, daysim_tour_number, determine_tour_mode
 
 logger = logging.getLogger(__name__)
 
@@ -56,17 +56,13 @@ def format_tours(
         how="left",
     )
 
-    # Number the tours within each person-day. tour_num cannot be used directly:
-    # a work-based subtour carries its parent's tour_num (subtour_num is what
-    # separates them), so the two would collide on DaySim's (hhno, pno, day,
-    # tour) key. The canonical tour_id already packs day / tour_num /
-    # subtour_num in travel order, so ranking it puts each parent immediately
-    # ahead of its own subtours.
+    # Number the tours within each person-day. See daysim_tour_number: the trips
+    # file must derive the same number or its trips point at the wrong tour.
     tours_daysim = tours_daysim.with_columns(
         hhno=pl.col("hh_id"),
         pno=pl.col("person_num"),
         day=pl.col("travel_dow"),
-        tour=pl.col("tour_id").rank("dense").over(["person_id", "day_id"]).cast(pl.Int16),
+        tour=daysim_tour_number(),
     )
 
     # Point each subtour at its parent's DaySim tour number. Home-based tours

--- a/src/processing/formatting/daysim/format_trips.py
+++ b/src/processing/formatting/daysim/format_trips.py
@@ -19,6 +19,7 @@ from data_canon.codebook.trips import (
 from .mappings import (
     DROVE_ACCESS_EGRESS,
     PURPOSE_MAP,
+    daysim_tour_number,
 )
 
 logger = logging.getLogger(__name__)
@@ -420,17 +421,21 @@ def _prepare_basic_fields(linked_trips: pl.DataFrame, persons: pl.DataFrame) -> 
     )
 
     # Compute Daysim trip identification fields:
-    # - tour: tour sequence number within person-day (from tour_num)
+    # - tour: tour sequence number within person-day (see daysim_tour_number)
     # - half: half-tour direction (1=OUTBOUND, 2=INBOUND, from tour_direction)
     # - tseg: trip sequence within half-tour (ranked by departure then arrival)
     # - tsvid: travel survey trip ID (use linked_trip_id)
     # - tripno: sequential trip number per person-day (bonus field)
+    #
+    # tour and tseg key off tour_id, not tour_num: a work-based subtour shares
+    # its parent's tour_num, so numbering trips by tour_num filed every subtour
+    # trip under its parent's tour -- leaving the subtour's own tour record with
+    # no trips, and double-counting the parent's half-tours.
     trips = trips.with_columns(
         [
-            # Use tour_num if it exists, otherwise create it
-            pl.col("tour_num").alias("tour")
-            if "tour_num" in linked_trips.columns
-            else pl.lit(1).alias("tour"),
+            daysim_tour_number().alias("tour")
+            if "tour_id" in linked_trips.columns
+            else pl.lit(1).cast(pl.Int16).alias("tour"),
             # Map tour_direction to half (1=OUTBOUND, 2=INBOUND)
             pl.col("tour_direction").alias("half")
             if "tour_direction" in linked_trips.columns
@@ -443,11 +448,11 @@ def _prepare_basic_fields(linked_trips: pl.DataFrame, persons: pl.DataFrame) -> 
             pl.col("depart_time")
             .rank(method="ordinal")
             .over(
-                ["hh_id", "person_id", "day_id", "tour_num", "tour_direction"],
+                ["hh_id", "person_id", "day_id", "tour_id", "tour_direction"],
                 order_by=["depart_time", "arrive_time"],
             )
             .alias("tseg")
-            if "tour_num" in linked_trips.columns and "tour_direction" in linked_trips.columns
+            if "tour_id" in linked_trips.columns and "tour_direction" in linked_trips.columns
             else pl.col("depart_time")
             .rank(method="ordinal")
             .over(

--- a/src/processing/formatting/daysim/mappings.py
+++ b/src/processing/formatting/daysim/mappings.py
@@ -281,3 +281,20 @@ def determine_tour_mode(tours: pl.DataFrame, linked_trips: pl.DataFrame) -> pl.D
     )
 
     return tours
+
+
+def daysim_tour_number() -> pl.Expr:
+    """DaySim's ``tour`` sequence number within a person-day.
+
+    ``tour_num`` cannot be used directly: a work-based subtour carries its
+    *parent's* ``tour_num`` (``subtour_num`` is what separates them), so parent
+    and subtour would collide on DaySim's ``(hhno, pno, day, tour)`` key. The
+    canonical ``tour_id`` already packs day / tour_num / subtour_num in travel
+    order, so ranking it puts each parent immediately ahead of its own subtours.
+
+    The tours file and the trips file must agree on this number or trips point
+    at a tour record they do not belong to, so both derive it from here rather
+    than restating the rule. Both frames are filtered by the same drop cascade
+    before formatting, so they rank over the same set of tours.
+    """
+    return pl.col("tour_id").rank("dense").over(["person_id", "day_id"]).cast(pl.Int16)

--- a/src/processing/tours/aggregation_helpers.py
+++ b/src/processing/tours/aggregation_helpers.py
@@ -414,7 +414,15 @@ def _assign_half_tour(
     Classifies each trip as:
     - OUTBOUND: Trips before first arrival at primary destination
     - INBOUND: Trips after final departure from primary destination
-    - SUBTOUR: Work-based subtour trips
+
+    Every tour has exactly two halves relative to its *own* anchor and primary
+    destination. That includes at-work subtours: a subtour is a separate tour
+    row with its own ``tour_id``, so its ``dest_arrive_time`` /
+    ``dest_depart_time`` already describe the subtour's own destination (e.g.
+    the lunch stop), and the same before/after rule splits it into outbound and
+    inbound. Direction and subtour membership are orthogonal facts -- membership
+    is carried by ``parent_tour_id`` / ``subtour_num`` / ``tour_type`` -- so
+    direction never encodes "this is a subtour".
 
     Args:
         linked_trips: Linked trips with tour_id assignments
@@ -444,16 +452,16 @@ def _assign_half_tour(
     # primary destination arrival/departure
     linked_trips = linked_trips.with_columns(
         [
-            # Subtours are identified by subtour_num > 0
-            pl.when(pl.col("subtour_num") > 0)
-            .then(pl.lit(TourDirection.SUBTOUR))
             # Outbound: trip arrives before or at first arrival at primary dest
-            .when(pl.col("arrive_time") <= pl.col("dest_arrive_time"))
+            pl.when(pl.col("arrive_time") <= pl.col("dest_arrive_time"))
             .then(pl.lit(TourDirection.OUTBOUND))
             # Inbound: trip departs after final departure from primary dest
             .when(pl.col("depart_time") >= pl.col("dest_depart_time"))
             .then(pl.lit(TourDirection.INBOUND))
-            # Default to outbound if times are null (shouldn't happen)
+            # Single-trip tours have no non-last trip, so they have no primary
+            # destination and the times above are null. They are flagged
+            # SINGLE_TRIP and dropped by the formatters, so the direction is
+            # never read; outbound is the harmless default.
             .otherwise(pl.lit(TourDirection.OUTBOUND))
             .alias("tour_direction"),
         ]

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -207,7 +207,16 @@ def _step_blocks(data_dir: Path, output_dir: Path, enabled: frozenset) -> dict:
                 "drop_missing_taz": True,
             },
         },
-        "format_daysim": {"name": "format_daysim", "validate_input": False, "cache": False},
+        # validate_output mirrors the shipping bats_2023 config. The DaySim row
+        # models pin the output schema (e.g. half must be 1 or 2), so a trip
+        # carrying an internal sentinel instead of a real value fails here
+        # rather than in a production run.
+        "format_daysim": {
+            "name": "format_daysim",
+            "validate_input": False,
+            "validate_output": True,
+            "cache": False,
+        },
         "write_data": {
             "name": "write_data",
             "validate_input": False,

--- a/tests/e2e/test_e2e_pipeline.py
+++ b/tests/e2e/test_e2e_pipeline.py
@@ -16,12 +16,13 @@ Two kinds of tests:
 """
 
 from pathlib import Path
+from typing import ClassVar
 
 import polars as pl
 import pytest
 
 from data_canon.codebook.ctramp import CTRAMPTourCategory
-from data_canon.codebook.tours import TourCategory, TourDataQuality, TourType
+from data_canon.codebook.tours import TourCategory, TourDataQuality, TourDirection, TourType
 from tests.e2e.assertions import assert_referential_integrity, assert_tables_non_empty
 
 pytestmark = [pytest.mark.e2e, pytest.mark.slow]
@@ -158,6 +159,48 @@ class TestTourExtraction:
             "a work tour and its at-work subtour must not share a CT-RAMP tour_id"
         )
         assert hh6["atWork_freq"].max() == 1, "the parent work tour should report one subtour"
+
+    def test_subtour_trips_have_a_real_direction(self, full_result):
+        # A subtour is split into halves against its own anchor (the workplace),
+        # like any other tour. Stamping both legs with a "subtour" sentinel threw
+        # the direction away, which DaySim (half) and CT-RAMP (inbound) require.
+        subtour_trips = full_result.linked_trips.filter(pl.col("subtour_num") > 0).sort(
+            "depart_time"
+        )
+        assert subtour_trips.height == 2
+        assert subtour_trips["tour_direction"].to_list() == [
+            TourDirection.OUTBOUND.value,
+            TourDirection.INBOUND.value,
+        ]
+
+
+class TestDaysimTourLinkage:
+    """DaySim trips must reference the tour records they belong to.
+
+    Schema validation alone does not cover this: a subtour trip filed under its
+    parent's tour number is individually well-formed, it just points at the
+    wrong tour. These assertions are what catch that.
+    """
+
+    _KEY: ClassVar[list[str]] = ["hhno", "pno", "day", "tour"]
+
+    def test_no_trip_references_a_missing_tour(self, full_result):
+        tour_keys = full_result.tours_daysim.select(self._KEY).unique()
+        trip_keys = full_result.linked_trips_daysim.select(self._KEY).unique()
+        orphans = trip_keys.join(tour_keys, on=self._KEY, how="anti")
+        assert orphans.height == 0, f"trips reference non-existent tours:\n{orphans}"
+
+    def test_no_tour_is_left_without_trips(self, full_result):
+        # The subtour's own tour record went trip-less when its trips were
+        # numbered by tour_num (shared with the parent) instead of tour_id.
+        tour_keys = full_result.tours_daysim.select(self._KEY).unique()
+        trip_keys = full_result.linked_trips_daysim.select(self._KEY).unique()
+        childless = tour_keys.join(trip_keys, on=self._KEY, how="anti")
+        assert childless.height == 0, f"tour records with no trips:\n{childless}"
+
+    def test_half_is_only_ever_outbound_or_inbound(self, full_result):
+        halves = set(full_result.linked_trips_daysim["half"].unique().to_list())
+        assert halves <= {1, 2}, f"DaySim half must be 1 or 2, got {sorted(halves)}"
 
 
 # ── Imputation (full profile) ─────────────────────────────────────────

--- a/tests/test_at_work_subtours.py
+++ b/tests/test_at_work_subtours.py
@@ -228,12 +228,23 @@ class TestSubtourClassification:
             TourType.WORK_BASED.value,
         }
 
-    def test_subtour_trips_are_marked_subtour_direction(self, extracted):
-        """The subtour's trips are half-tour SUBTOUR, not outbound/inbound."""
+    def test_subtour_trips_get_a_real_direction(self, extracted):
+        """A subtour is split into outbound/inbound like any other tour.
+
+        Direction is relative to the tour's *own* anchor and primary
+        destination, so the leg out to the subtour activity is OUTBOUND and the
+        leg back to the workplace is INBOUND. Stamping both "SUBTOUR" instead
+        discarded the direction DaySim (``half``) and CT-RAMP (``inbound``)
+        need; subtour membership is carried by ``subtour_num`` /
+        ``parent_tour_id`` / ``tour_type``.
+        """
         linked_trips = extracted[0]["linked_trips"]
-        subtour_trips = linked_trips.filter(pl.col("subtour_num") > 0)
+        subtour_trips = linked_trips.filter(pl.col("subtour_num") > 0).sort("depart_time")
         assert len(subtour_trips) == 2
-        assert set(subtour_trips["tour_direction"].to_list()) == {TourDirection.SUBTOUR.value}
+        assert subtour_trips["tour_direction"].to_list() == [
+            TourDirection.OUTBOUND.value,
+            TourDirection.INBOUND.value,
+        ]
 
 
 def _gate(tours: pl.DataFrame) -> dict[int, bool]:
@@ -347,10 +358,10 @@ class TestSubtourReachesCtramp:
                     trip_id=2, tour_id=11000, person_id=101, tour_direction=TourDirection.INBOUND
                 ),
                 create_linked_trip(
-                    trip_id=3, tour_id=11010, person_id=101, tour_direction=TourDirection.SUBTOUR
+                    trip_id=3, tour_id=11010, person_id=101, tour_direction=TourDirection.OUTBOUND
                 ),
                 create_linked_trip(
-                    trip_id=4, tour_id=11010, person_id=101, tour_direction=TourDirection.SUBTOUR
+                    trip_id=4, tour_id=11010, person_id=101, tour_direction=TourDirection.INBOUND
                 ),
             ]
         )


### PR DESCRIPTION
Closes #87.

`tour_direction` fused two orthogonal facts: which half of the tour a trip is on, and whether it belongs to a subtour. Every subtour trip was stamped `SUBTOUR=3`, throwing away the direction both formatters need.

- **DaySim**: `half` is spec'd 1-2, so subtour trips emitted `half=3` and failed output validation — which the production bats_2023 config enables. The run would die at `format_daysim`.
- **CT-RAMP**: `inbound` is derived as `direction == INBOUND`, so both legs of a subtour got `inbound=0`. Per MTC's `HouseholdDataWriter`, at-work subtours pass through the same `writeIndivTourData` as every other tour and get outbound and inbound halves, so the return leg should be 1. No crash, just a silently wrong column.

Subtours are already separate tour rows with their own `tour_id` and destination times, so dropping the `SUBTOUR` branch in `_assign_half_tour` lets the existing before/after-primary-destination rule classify them. Membership stays in `parent_tour_id` / `subtour_num` / `tour_type`.

### Linked defect this exposed

DaySim's tours file numbers tours by ranking `tour_id`, because a subtour shares its parent's `tour_num`. The trips file used `tour_num` directly. So subtour trips were filed under the parent's tour number while the subtour's own tour record had no trips at all — and fixing `half` alone would have turned that from a loud schema failure into silent corruption. Both files now derive the number from `daysim_tour_number()`, and `tseg` partitions on `tour_id`.

Also removed `num_subtour_stops` from the CT-RAMP joint tour formatter: computed, never selected into output, and meaningless on joint tours.

### Verification

e2e now runs `format_daysim` with `validate_output` enabled, mirroring production, plus assertions that no DaySim trip references a missing tour and no tour record is left without trips. Both defects were confirmed to reproduce on the pre-fix code (`half` values `[1,2,3]`, one childless tour) and to be gone after. 927 tests pass.

### Note for anyone rerunning

Cache keys hash inputs and params, not step code, so existing `extract_tours` caches still hold `direction=3`. Clear `.cache/*/extract_tours` and downstream before the next run.
