### PR TITLE
Resolve config shorthands that refer to other shorthands

### DIFF
--- a/src/pipeline/pipeline.py
+++ b/src/pipeline/pipeline.py
@@ -17,6 +17,54 @@ from pipeline.logger import setup_logging
 
 logger = logging.getLogger(__name__)
 
+# Enough passes to resolve any sane chain of shorthands referring to shorthands,
+# and few enough that a cycle is reported rather than spun on.
+MAX_TEMPLATE_PASSES = 10
+
+
+def _substitute(text: str, variables: dict[str, str]) -> str:
+    """Replace every ``{{ name }}`` in one string with its value."""
+    for name, value in variables.items():
+        text = text.replace(f"{{{{ {name} }}}}", str(value))
+    return text
+
+
+def _resolve_variables(variables: dict[str, str]) -> dict[str, str]:
+    """Expand the shorthands against each other before anything else uses them.
+
+    Config shorthands routinely refer to other shorthands
+    (``output_dir: "{{ survey_dir }}/analysis"``). Substituting in a single pass
+    resolves such a reference only when its target happens to be declared later
+    in the file, because the pass has already moved past an earlier one -- so
+    the same config works or silently emits a literal ``{{ survey_dir }}`` path
+    depending on the order its keys were written in. Resolving the shorthands
+    to a fixed point first makes declaration order irrelevant.
+
+    Args:
+        variables: Top-level string values from the config, unexpanded.
+
+    Returns:
+        The same mapping with every nested reference expanded.
+
+    Raises:
+        ValueError: A reference could not be resolved within
+            ``MAX_TEMPLATE_PASSES``, which means the shorthands refer to each
+            other in a cycle.
+    """
+    resolved = dict(variables)
+    for _ in range(MAX_TEMPLATE_PASSES):
+        expanded = {key: _substitute(value, resolved) for key, value in resolved.items()}
+        if expanded == resolved:
+            return resolved
+        resolved = expanded
+
+    unresolved = sorted(key for key, value in resolved.items() if "{{" in value)
+    msg = (
+        f"Config variables still reference each other after {MAX_TEMPLATE_PASSES} "
+        f"passes: {unresolved}. They likely refer to each other in a cycle."
+    )
+    raise ValueError(msg)
+
 
 class Pipeline:
     """Class to run a data processing pipeline based on a configuration file."""
@@ -103,14 +151,11 @@ class Pipeline:
 
         # Extract top-level variables for substitution
         variables = {key: value for key, value in config.items() if isinstance(value, str)}
+        variables = _resolve_variables(variables)
 
-        # Recursively replace template variables
         def replace_templates(obj: Any) -> Any:  # noqa: ANN401
             if isinstance(obj, str):
-                # Replace {{ variable_name }} with actual values
-                for var_name, var_value in variables.items():
-                    obj = obj.replace(f"{{{{ {var_name} }}}}", str(var_value))
-                return obj
+                return _substitute(obj, variables)
 
             if isinstance(obj, dict):
                 return {k: replace_templates(v) for k, v in obj.items()}

--- a/tests/test_pipeline_templating.py
+++ b/tests/test_pipeline_templating.py
@@ -1,0 +1,103 @@
+"""Tests for config shorthand resolution.
+
+A config shorthand may refer to another shorthand, which is how projects hang
+every output off one root:
+
+    survey_dir: "M:/.../WeightedDataset"
+    output_dir: "{{ survey_dir }}/pipeline_analysis"
+
+Substituting in one pass makes that work only when the referenced shorthand is
+declared *after* the one referring to it, so the same config resolves or emits a
+literal ``{{ survey_dir }}`` directory depending on the order its keys happen to
+be written in. These tests pin the order-independence.
+"""
+
+import pytest
+import yaml
+
+from pipeline.pipeline import MAX_TEMPLATE_PASSES, Pipeline, _resolve_variables
+
+
+def _load(tmp_path, config: dict) -> dict:
+    """Write a config and return it as Pipeline loads it."""
+    path = tmp_path / "config.yaml"
+    path.write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
+    return Pipeline(config_path=str(path), steps=[]).config
+
+
+def test_shorthand_referring_to_an_earlier_shorthand_resolves(tmp_path):
+    """The regression: the target is declared *before* the reference."""
+    config = _load(
+        tmp_path,
+        {
+            "survey_dir": "M:/survey",
+            "output_dir": "{{ survey_dir }}/pipeline_analysis",
+            "steps": [{"name": "load_data", "params": {"out": "{{ output_dir }}/x.csv"}}],
+        },
+    )
+
+    assert config["output_dir"] == "M:/survey/pipeline_analysis"
+    assert config["steps"][0]["params"]["out"] == "M:/survey/pipeline_analysis/x.csv"
+
+
+def test_resolution_does_not_depend_on_declaration_order(tmp_path):
+    """Declaring the target after the reference gives the identical result."""
+    reversed_order = _load(
+        tmp_path,
+        {
+            "output_dir": "{{ survey_dir }}/pipeline_analysis",
+            "survey_dir": "M:/survey",
+            "steps": [{"name": "load_data", "params": {"out": "{{ output_dir }}/x.csv"}}],
+        },
+    )
+
+    assert reversed_order["output_dir"] == "M:/survey/pipeline_analysis"
+    assert reversed_order["steps"][0]["params"]["out"] == "M:/survey/pipeline_analysis/x.csv"
+
+
+def test_chained_shorthands_resolve():
+    """A reference several links deep still bottoms out."""
+    resolved = _resolve_variables(
+        {
+            "root": "M:/data",
+            "survey_dir": "{{ root }}/survey",
+            "output_dir": "{{ survey_dir }}/analysis",
+            "log_file": "{{ output_dir }}/run.log",
+        }
+    )
+
+    assert resolved["log_file"] == "M:/data/survey/analysis/run.log"
+
+
+def test_no_template_leaks_into_a_resolved_path(tmp_path):
+    """No resolved value keeps an unexpanded marker, which becomes a real path."""
+    config = _load(
+        tmp_path,
+        {
+            "survey_dir": "M:/survey",
+            "output_dir": "{{ survey_dir }}/out",
+            "log_file": "{{ output_dir }}/run.log",
+            "steps": [],
+        },
+    )
+
+    leaked = [key for key, value in config.items() if isinstance(value, str) and "{{" in value]
+    assert not leaked, f"unexpanded template left in {leaked}"
+
+
+def test_a_cycle_is_reported_rather_than_spun_on():
+    """Shorthands referring to each other raise instead of looping forever."""
+    with pytest.raises(ValueError, match="cycle"):
+        _resolve_variables({"a": "{{ b }}/x", "b": "{{ a }}/y"})
+
+
+def test_unknown_reference_is_left_alone():
+    """A reference to something undeclared is not an error here.
+
+    Nothing at this layer knows which strings are meant to be paths, so an
+    unrecognised marker is passed through untouched rather than guessed at.
+    """
+    resolved = _resolve_variables({"a": "{{ nowhere }}/x"})
+
+    assert resolved["a"] == "{{ nowhere }}/x"
+    assert MAX_TEMPLATE_PASSES > 1


### PR DESCRIPTION
`output_dir: "{{ survey_dir }}/pipeline_analysis"` did not resolve — it produced a literal `{{ survey_dir }}` directory on disk.

Substitution read its variable values from the raw config and applied them in a single pass, in declaration order. A reference resolved only if its target was declared *after* it, so `survey_dir` (declared first) was never expanded inside `output_dir`.

Now the shorthands resolve against each other to a fixed point before substitution: declaration order stops mattering, chains of any depth bottom out, and a reference cycle raises instead of leaving an unexpanded path behind.

6 tests, two of which fail without the fix. Full suite passes (1004).

🤖 Generated with [Claude Code](https://claude.com/claude-code)