### PR TITLE
Optionally break a linked trip where the travelling party changes

### DIFF
--- a/projects/bats_2019/config.yaml
+++ b/projects/bats_2019/config.yaml
@@ -41,6 +41,10 @@ steps:
       transit_mode_enums: [FERRY, TRANSIT, LONG_DISTANCE]
       max_dwell_time: 180  # in minutes
       dwell_buffer_distance: 100  # in meters
+      # Break a linked trip where the reported party size changes between
+      # segments, on the reading that somebody was picked up or dropped off
+      # rather than transferring. No default: state the choice explicitly.
+      split_on_occupancy: false
 
   - name: detect_joint_trips
     validate_input: true

--- a/projects/bats_2023/config.yaml
+++ b/projects/bats_2023/config.yaml
@@ -100,6 +100,10 @@ steps:
       transit_mode_enums: [FERRY, TRANSIT, LONG_DISTANCE]
       max_dwell_time: 180  # in minutes
       dwell_buffer_distance: 100  # in meters
+      # Break a linked trip where the reported party size changes between
+      # segments, on the reading that somebody was picked up or dropped off
+      # rather than transferring. No default: state the choice explicitly.
+      split_on_occupancy: false
 
   - name: detect_joint_trips
     validate_input: false

--- a/src/processing/link_trips/link.py
+++ b/src/processing/link_trips/link.py
@@ -65,6 +65,7 @@ def link_trips(
     transit_mode_enums: list[str],
     max_dwell_time: float = 120,
     dwell_buffer_distance: float = 100,
+    split_on_occupancy: bool = False,
 ) -> dict[str, pl.DataFrame]:
     """Link unlinked trip segments into complete journey records.
 
@@ -80,6 +81,10 @@ def link_trips(
             minutes (default: 120).
         dwell_buffer_distance: Maximum spatial distance between trips to link,
             in meters (default: 100).
+        split_on_occupancy: Refuse to link two segments whose reported party
+            size differs (default: False). A change of occupancy at a stop is
+            evidence that somebody was picked up or dropped off, which makes
+            the stop an activity rather than a transfer.
 
     Returns:
         Dictionary containing:
@@ -132,6 +137,7 @@ def link_trips(
         change_mode_enum,
         max_dwell_time,
         dwell_buffer_distance,
+        split_on_occupancy=split_on_occupancy,
     )
 
     # Aggregate linked trips
@@ -152,6 +158,8 @@ def link_trip_ids(
     change_mode_enum: str,
     max_dwell_time: float = 120,
     dwell_buffer_distance: float = 100,
+    *,
+    split_on_occupancy: bool = False,
 ) -> pl.DataFrame:
     """Link trips based on purpose and mode in time sequence.
 
@@ -169,9 +177,15 @@ def link_trip_ids(
         change_mode_enum: Enum label indicating a mode change
         max_dwell_time: Maximum time gap between trips to link them (minutes)
         dwell_buffer_distance: Maximum distance between trips to link (meters)
+        split_on_occupancy: Also break the link where the reported party size
+            changes between segments
 
     Returns:
         DataFrame with linked_trip_id column added
+
+    Raises:
+        ValueError: split_on_occupancy is set but the trips carry no
+            num_travelers column to compare.
 
     """
     logger.info("Linking trip IDs...")
@@ -190,12 +204,19 @@ def link_trip_ids(
     # Step 1: Sort trips by person, day, and departure time
     unlinked_trips = unlinked_trips.sort(["person_id", "day_id", "depart_time", "arrive_time"])
 
+    if split_on_occupancy and "num_travelers" not in unlinked_trips.columns:
+        msg = (
+            "split_on_occupancy is enabled but unlinked_trips has no num_travelers "
+            "column, so a change of party size cannot be detected."
+        )
+        raise ValueError(msg)
+
     # Step 2: Get previous trip purpose category within the same person
+    shift_cols = ["d_purpose_category", "d_lon", "d_lat", "arrive_time"]
+    if split_on_occupancy:
+        shift_cols.append("num_travelers")
     unlinked_trips = unlinked_trips.with_columns(
-        pl.col("d_purpose_category", "d_lon", "d_lat", "arrive_time")
-        .shift(fill_value=None)
-        .over("person_id")
-        .name.map(lambda c: f"prev_{c}")
+        pl.col(shift_cols).shift(fill_value=None).over("person_id").name.map(lambda c: f"prev_{c}")
     )
 
     # Get change mode integer code value from enum label
@@ -208,28 +229,35 @@ def link_trip_ids(
     #  - prev_purpose is missing
     #  - distance between prev_d_coord and o_coord > threshold
     #  - time between prev_arrive_time and depart_time > threshold
-    unlinked_trips = unlinked_trips.with_columns(
-        [
-            (
-                (pl.col("prev_d_purpose_category") != change_mode_code)
-                | pl.col("prev_d_purpose_category").is_null()
-                | (
-                    expr_haversine(
-                        pl.col("prev_d_lat"),
-                        pl.col("prev_d_lon"),
-                        pl.col("o_lat"),
-                        pl.col("o_lon"),
-                    )
-                    > dwell_buffer_distance
-                )
-                | (
-                    ((pl.col("depart_time") - pl.col("prev_arrive_time")).dt.total_minutes())
-                    > max_dwell_time
-                )
+    starts_new_trip = (
+        (pl.col("prev_d_purpose_category") != change_mode_code)
+        | pl.col("prev_d_purpose_category").is_null()
+        | (
+            expr_haversine(
+                pl.col("prev_d_lat"),
+                pl.col("prev_d_lon"),
+                pl.col("o_lat"),
+                pl.col("o_lon"),
             )
-            .cast(pl.Int32)
-            .alias("new_trip_flag"),
-        ]
+            > dwell_buffer_distance
+        )
+        | (
+            ((pl.col("depart_time") - pl.col("prev_arrive_time")).dt.total_minutes())
+            > max_dwell_time
+        )
+    )
+
+    if split_on_occupancy:
+        # Only a reported change breaks the link. An unreported party size on
+        # either side is missing data, not evidence that anybody got in or out.
+        starts_new_trip = starts_new_trip | (
+            pl.col("num_travelers").is_not_null()
+            & pl.col("prev_num_travelers").is_not_null()
+            & (pl.col("num_travelers") != pl.col("prev_num_travelers"))
+        )
+
+    unlinked_trips = unlinked_trips.with_columns(
+        starts_new_trip.cast(pl.Int32).alias("new_trip_flag")
     )
 
     # Step 4: Assign linked trip IDs using cumulative sum
@@ -243,14 +271,45 @@ def link_trip_ids(
     unlinked_trips_with_id = create_linked_trip_id(unlinked_trips)
 
     # Step 6: Clean up temporary columns
-    return unlinked_trips_with_id.drop(
-        [
-            "prev_d_purpose_category",
-            "prev_d_lon",
-            "prev_d_lat",
-            "prev_arrive_time",
-            "new_trip_flag",
-        ]
+    temp_cols = [
+        "prev_d_purpose_category",
+        "prev_d_lon",
+        "prev_d_lat",
+        "prev_arrive_time",
+        "new_trip_flag",
+    ]
+    if split_on_occupancy:
+        temp_cols.append("prev_num_travelers")
+    return unlinked_trips_with_id.drop(temp_cols)
+
+
+def _warn_on_occupancy_change(unlinked_trips: pl.DataFrame) -> None:
+    """Report linked trips whose party size changes between segments.
+
+    ``num_travelers`` is rolled up with a max, which silently reports the
+    largest party as though it applied to the whole journey. A party that
+    changes mid-journey usually means somebody was picked up or dropped off,
+    making the stop an activity rather than a transfer -- so the link itself is
+    suspect, not just the count. Linking with ``split_on_occupancy`` enabled
+    keeps those segments apart and silences this warning.
+    """
+    if "num_travelers" not in unlinked_trips.columns:
+        return
+
+    varying = (
+        unlinked_trips.group_by("linked_trip_id")
+        .agg(pl.col("num_travelers").drop_nulls().n_unique().alias("_n_sizes"))
+        .filter(pl.col("_n_sizes") > 1)
+    )
+    if varying.is_empty():
+        return
+
+    logger.warning(
+        "%d linked trip(s) change party size between segments; num_travelers reports "
+        "the largest. This usually indicates a pick-up or drop-off that was linked as "
+        "a transfer -- consider link_trips(split_on_occupancy=True). Examples: %s",
+        varying.height,
+        varying["linked_trip_id"].head(5).to_list(),
     )
 
 
@@ -279,6 +338,7 @@ def aggregate_linked_trips(
 
     """
     logger.info("Aggregating linked trips...")
+    _warn_on_occupancy_change(unlinked_trips)
 
     transit_mode_codes = resolve_enum_labels(
         table_name="unlinked_trips",

--- a/src/processing/link_trips/link.py
+++ b/src/processing/link_trips/link.py
@@ -65,7 +65,8 @@ def link_trips(
     transit_mode_enums: list[str],
     max_dwell_time: float = 120,
     dwell_buffer_distance: float = 100,
-    split_on_occupancy: bool = False,
+    *,
+    split_on_occupancy: bool,
 ) -> dict[str, pl.DataFrame]:
     """Link unlinked trip segments into complete journey records.
 
@@ -82,9 +83,12 @@ def link_trips(
         dwell_buffer_distance: Maximum spatial distance between trips to link,
             in meters (default: 100).
         split_on_occupancy: Refuse to link two segments whose reported party
-            size differs (default: False). A change of occupancy at a stop is
-            evidence that somebody was picked up or dropped off, which makes
-            the stop an activity rather than a transfer.
+            size differs. A change of occupancy at a stop is evidence that
+            somebody was picked up or dropped off, which makes the stop an
+            activity rather than a transfer. Required, and deliberately without
+            a default: either answer changes what a linked trip *is*, so the
+            choice belongs to whoever configured the run rather than to this
+            signature.
 
     Returns:
         Dictionary containing:
@@ -159,7 +163,7 @@ def link_trip_ids(
     max_dwell_time: float = 120,
     dwell_buffer_distance: float = 100,
     *,
-    split_on_occupancy: bool = False,
+    split_on_occupancy: bool,
 ) -> pl.DataFrame:
     """Link trips based on purpose and mode in time sequence.
 
@@ -178,7 +182,7 @@ def link_trip_ids(
         max_dwell_time: Maximum time gap between trips to link them (minutes)
         dwell_buffer_distance: Maximum distance between trips to link (meters)
         split_on_occupancy: Also break the link where the reported party size
-            changes between segments
+            changes between segments. Required; see ``link_trips``.
 
     Returns:
         DataFrame with linked_trip_id column added

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -149,6 +149,7 @@ def _step_blocks(data_dir: Path, output_dir: Path, enabled: frozenset) -> dict:
                 "transit_mode_enums": ["FERRY", "TRANSIT", "LONG_DISTANCE"],
                 "max_dwell_time": 180,
                 "dwell_buffer_distance": 100,
+                "split_on_occupancy": False,
             },
         },
         "detect_joint_trips": {

--- a/tests/fixtures/fixtures.py
+++ b/tests/fixtures/fixtures.py
@@ -280,6 +280,7 @@ def process_scenario_through_pipeline(
         transit_mode_enums=DEFAULT_TRANSIT_MODE_CODES,
         max_dwell_time=180,  # in minutes
         dwell_buffer_distance=100,  # in meters
+        split_on_occupancy=False,
     )
     linked_trips = link_result["linked_trips"].with_columns(
         pl.lit(None).cast(pl.Int64).alias("joint_trip_id")

--- a/tests/test_alternate_work.py
+++ b/tests/test_alternate_work.py
@@ -103,6 +103,7 @@ def _extract(persons, households, unlinked_trips):
         unlinked_trips=unlinked_trips,
         change_mode_enum=PurposeCategory.CHANGE_MODE.value,
         transit_mode_enums=[ModeType.TRANSIT.value],
+        split_on_occupancy=False,
     )
     linked_trips = link_result["linked_trips"].with_columns(
         pl.lit(None).cast(pl.Int64).alias("joint_trip_id")

--- a/tests/test_at_work_subtours.py
+++ b/tests/test_at_work_subtours.py
@@ -170,6 +170,7 @@ def extracted():
         unlinked_trips=_lunch_subtour_day(),
         change_mode_enum=PurposeCategory.CHANGE_MODE.value,
         transit_mode_enums=[ModeType.TRANSIT.value],
+        split_on_occupancy=False,
     )
     linked_trips = link_result["linked_trips"].with_columns(
         pl.lit(None).cast(pl.Int64).alias("joint_trip_id")

--- a/tests/test_daysim_formatting.py
+++ b/tests/test_daysim_formatting.py
@@ -865,6 +865,7 @@ class TestTripFormatting:
             unlinked_trips,
             change_mode_enum=PurposeCategory.CHANGE_MODE.value,
             transit_mode_enums=[Mode.BART.value, Mode.BUS_LOCAL.value],
+            split_on_occupancy=False,
         )
 
         unlinked_trips_with_ids = result_dict["unlinked_trips"]
@@ -919,6 +920,7 @@ class TestTripFormatting:
             unlinked_trips,
             change_mode_enum=PurposeCategory.CHANGE_MODE.value,
             transit_mode_enums=[Mode.BART.value, Mode.BUS_LOCAL.value],
+            split_on_occupancy=False,
         )
 
         unlinked_trips_with_ids = result_dict["unlinked_trips"]
@@ -974,6 +976,7 @@ class TestTripFormatting:
             unlinked_trips,
             change_mode_enum=PurposeCategory.CHANGE_MODE.value,
             transit_mode_enums=[Mode.BART.value, Mode.BUS_LOCAL.value],
+            split_on_occupancy=False,
         )
 
         unlinked_trips_with_ids = result_dict["unlinked_trips"]
@@ -1029,6 +1032,7 @@ class TestTripFormatting:
             unlinked_trips,
             change_mode_enum=PurposeCategory.CHANGE_MODE.value,
             transit_mode_enums=[Mode.BART.value, Mode.BUS_LOCAL.value],
+            split_on_occupancy=False,
         )
 
         unlinked_trips_with_ids = result_dict["unlinked_trips"]
@@ -1085,6 +1089,7 @@ class TestTripFormatting:
             unlinked_trips,
             change_mode_enum=PurposeCategory.CHANGE_MODE.value,
             transit_mode_enums=[Mode.BART.value, Mode.BUS_LOCAL.value],
+            split_on_occupancy=False,
         )
 
         unlinked_trips_with_ids = result_dict["unlinked_trips"]
@@ -1136,6 +1141,7 @@ class TestTripFormatting:
             unlinked_trips,
             change_mode_enum=PurposeCategory.CHANGE_MODE.value,
             transit_mode_enums=[Mode.BART.value, Mode.BUS_LOCAL.value],
+            split_on_occupancy=False,
         )
 
         unlinked_trips_with_ids = result_dict["unlinked_trips"]
@@ -1190,6 +1196,7 @@ class TestTripFormatting:
             unlinked_trips,
             change_mode_enum=PurposeCategory.CHANGE_MODE.value,
             transit_mode_enums=[Mode.BART.value, Mode.BUS_LOCAL.value],
+            split_on_occupancy=False,
         )
 
         unlinked_trips_with_ids = result_dict["unlinked_trips"]
@@ -1395,6 +1402,7 @@ class TestEndToEndDaysimFormatting:
             unlinked_trips_fixture,
             change_mode_enum=PurposeCategory.CHANGE_MODE.value,
             transit_mode_enums=[Mode.BART.value],
+            split_on_occupancy=False,
         )
 
         # Add joint_trip_id for extract_tours validation

--- a/tests/test_duration_tiebreaker.py
+++ b/tests/test_duration_tiebreaker.py
@@ -66,6 +66,7 @@ def create_test_data(
         transit_mode_enums=[12, 13, 14],
         max_dwell_time=180,  # in minutes
         dwell_buffer_distance=100,  # in meters
+        split_on_occupancy=False,
     ).values()
 
     # Add joint_trip_id column for extract_tours validation

--- a/tests/test_joint_tours.py
+++ b/tests/test_joint_tours.py
@@ -89,6 +89,7 @@ def link_and_detect_joint_trips(
         unlinked_trips=unlinked_trips,
         change_mode_enum=PurposeCategory.CHANGE_MODE.value,
         transit_mode_enums=[ModeType.TRANSIT.value],
+        split_on_occupancy=False,
     )
     unlinked_trips_with_ids = link_result["unlinked_trips"]
     linked_trips = link_result["linked_trips"]

--- a/tests/test_link_trips_core.py
+++ b/tests/test_link_trips_core.py
@@ -52,6 +52,7 @@ class TestLinkTripIds:
             change_mode_enum=10,
             max_dwell_time=120,
             dwell_buffer_distance=100,
+            split_on_occupancy=False,
         )
 
         # Both trips should have same linked_trip_id
@@ -93,6 +94,7 @@ class TestLinkTripIds:
             change_mode_enum=10,
             max_dwell_time=120,
             dwell_buffer_distance=100,
+            split_on_occupancy=False,
         )
 
         # Each trip should have different linked_trip_id
@@ -130,6 +132,7 @@ class TestLinkTripIds:
             change_mode_enum=10,
             max_dwell_time=120,
             dwell_buffer_distance=100,
+            split_on_occupancy=False,
         )
 
         # Each person should have unique linked_trip_id
@@ -167,6 +170,7 @@ class TestLinkTripIds:
             change_mode_enum=10,
             max_dwell_time=120,  # 120 minutes
             dwell_buffer_distance=100,
+            split_on_occupancy=False,
         )
 
         # Should not link due to time gap
@@ -204,6 +208,7 @@ class TestLinkTripIds:
             change_mode_enum=10,
             max_dwell_time=120,
             dwell_buffer_distance=10,  # 10 miles
+            split_on_occupancy=False,
         )
 
         # Should not link due to distance
@@ -252,6 +257,7 @@ class TestLinkTripIds:
             change_mode_enum=10,
             max_dwell_time=120,
             dwell_buffer_distance=100,
+            split_on_occupancy=False,
         )
 
         # All three trips should have same linked_trip_id
@@ -301,6 +307,7 @@ class TestLinkTripIds:
             change_mode_enum=10,
             max_dwell_time=120,
             dwell_buffer_distance=100,
+            split_on_occupancy=False,
         )
 
         # All linked_trip_ids should be unique globally
@@ -338,6 +345,7 @@ class TestLinkTripIds:
             change_mode_enum=10,
             max_dwell_time=120,
             dwell_buffer_distance=100,
+            split_on_occupancy=False,
         )
 
         # Should still process without error
@@ -366,6 +374,7 @@ class TestLinkTripIds:
             change_mode_enum=10,
             max_dwell_time=120,
             dwell_buffer_distance=100,
+            split_on_occupancy=False,
         )
 
         assert len(result) == 0
@@ -764,6 +773,7 @@ class TestLinkTripsIntegration:
             transit_mode_enums=[ModeType.TRANSIT.value],
             max_dwell_time=120,
             dwell_buffer_distance=100,
+            split_on_occupancy=False,
         )
 
         # Should return dict with two DataFrames
@@ -820,6 +830,7 @@ class TestLinkTripsIntegration:
             change_mode_enum=10,
             transit_mode_enums=[ModeType.TRANSIT.value],
             max_dwell_time=120,
+            split_on_occupancy=False,
         )
 
         linked_trips = result["linked_trips"]
@@ -1207,6 +1218,7 @@ class TestTableLevelUniqueness:
             change_mode_enum=PurposeCategory.CHANGE_MODE.value,
             transit_mode_enums=[ModeType.TRANSIT.value],
             max_dwell_time=120,
+            split_on_occupancy=False,
         )
 
         unlinked_trips = result["unlinked_trips"]

--- a/tests/test_link_trips_occupancy.py
+++ b/tests/test_link_trips_occupancy.py
@@ -6,13 +6,18 @@ somebody was picked up or dropped off, which makes the stop an activity rather
 than a transfer. ``split_on_occupancy`` refuses the link in that case.
 """
 
+import inspect
 import logging
 from datetime import datetime
 
 import polars as pl
 import pytest
 
-from processing.link_trips.link import _warn_on_occupancy_change, link_trip_ids
+from processing.link_trips.link import (
+    _warn_on_occupancy_change,
+    link_trip_ids,
+    link_trips,
+)
 
 CHANGE_MODE = 10
 
@@ -126,3 +131,18 @@ def test_splitting_removes_the_warning(caplog):
         _warn_on_occupancy_change(linked)
 
     assert "change party size" not in caplog.text
+
+
+def test_the_choice_has_no_default():
+    """No default, so a run cannot leave this decision unmade.
+
+    Either answer changes what a linked trip *is*, and a default would quietly
+    pick one on the configuration's behalf.
+    """
+    for func in (link_trips, link_trip_ids):
+        parameter = inspect.signature(func).parameters["split_on_occupancy"]
+        assert parameter.default is inspect.Parameter.empty, (
+            f"{func.__name__} gives split_on_occupancy a default, which decides "
+            f"trip linking semantics for every config that stays silent"
+        )
+        assert parameter.kind is inspect.Parameter.KEYWORD_ONLY

--- a/tests/test_link_trips_occupancy.py
+++ b/tests/test_link_trips_occupancy.py
@@ -1,0 +1,128 @@
+"""Tests for breaking a linked trip where the travelling party changes.
+
+Two segments joined at a mode-change stop are treated as one journey. If the
+number of travellers differs across that stop, the more likely reading is that
+somebody was picked up or dropped off, which makes the stop an activity rather
+than a transfer. ``split_on_occupancy`` refuses the link in that case.
+"""
+
+import logging
+from datetime import datetime
+
+import polars as pl
+import pytest
+
+from processing.link_trips.link import _warn_on_occupancy_change, link_trip_ids
+
+CHANGE_MODE = 10
+
+
+def _two_segments(num_travelers: list[int | None]) -> pl.DataFrame:
+    """Two segments meeting at a change-mode stop, close in time and space.
+
+    Everything except the party size satisfies the linking rules, so any break
+    in these tests is attributable to occupancy alone.
+    """
+    return pl.DataFrame(
+        {
+            "day_id": [10001, 10001],
+            "person_id": [100, 100],
+            "depart_time": [datetime(2024, 1, 1, 8, 0), datetime(2024, 1, 1, 8, 15)],
+            "arrive_time": [datetime(2024, 1, 1, 8, 10), datetime(2024, 1, 1, 8, 45)],
+            "d_purpose_category": [CHANGE_MODE, 1],
+            "o_lat": [37.7, 37.71],
+            "o_lon": [-122.4, -122.41],
+            "d_lat": [37.71, 37.75],
+            "d_lon": [-122.41, -122.45],
+            "num_travelers": num_travelers,
+        },
+        schema_overrides={"num_travelers": pl.Int64},
+    )
+
+
+def _link(trips: pl.DataFrame, *, split: bool) -> pl.DataFrame:
+    return link_trip_ids(
+        trips,
+        change_mode_enum=CHANGE_MODE,
+        max_dwell_time=120,
+        dwell_buffer_distance=100,
+        split_on_occupancy=split,
+    )
+
+
+def test_party_change_breaks_the_link_when_enabled():
+    """One traveller becoming three is a pick-up, not a transfer."""
+    result = _link(_two_segments([1, 3]), split=True)
+
+    assert result["linked_trip_id"].n_unique() == 2
+
+
+def test_party_change_is_linked_when_disabled():
+    """Default behaviour is unchanged, so existing projects are unaffected."""
+    result = _link(_two_segments([1, 3]), split=False)
+
+    assert result["linked_trip_id"].n_unique() == 1
+
+
+def test_steady_party_still_links():
+    """Splitting on occupancy must not break an ordinary transfer."""
+    result = _link(_two_segments([2, 2]), split=True)
+
+    assert result["linked_trip_id"].n_unique() == 1
+
+
+@pytest.mark.parametrize("sizes", [[None, 3], [1, None], [None, None]])
+def test_unreported_party_size_does_not_break_the_link(sizes):
+    """A missing party size is missing data, not evidence of a change."""
+    result = _link(_two_segments(sizes), split=True)
+
+    assert result["linked_trip_id"].n_unique() == 1
+
+
+def test_missing_column_is_refused_rather_than_ignored():
+    """Asking to split with nothing to split on is an error, not a silent no-op."""
+    trips = _two_segments([1, 3]).drop("num_travelers")
+
+    with pytest.raises(ValueError, match="num_travelers"):
+        _link(trips, split=True)
+
+
+def test_aggregation_warns_when_a_party_changes_inside_a_link(caplog):
+    """The max() roll-up stays, but it announces what it is papering over."""
+    linked = _link(_two_segments([1, 3]), split=False)
+
+    with caplog.at_level(logging.WARNING, logger="processing.link_trips.link"):
+        _warn_on_occupancy_change(linked)
+
+    assert "change party size between segments" in caplog.text
+    assert "split_on_occupancy=True" in caplog.text
+
+
+def test_no_warning_when_the_party_holds(caplog):
+    """A steady party must not produce noise."""
+    linked = _link(_two_segments([2, 2]), split=False)
+
+    with caplog.at_level(logging.WARNING, logger="processing.link_trips.link"):
+        _warn_on_occupancy_change(linked)
+
+    assert "change party size" not in caplog.text
+
+
+def test_no_warning_when_the_party_was_never_reported(caplog):
+    """Nulls alone are not a change, so they must not warn either."""
+    linked = _link(_two_segments([None, None]), split=False)
+
+    with caplog.at_level(logging.WARNING, logger="processing.link_trips.link"):
+        _warn_on_occupancy_change(linked)
+
+    assert "change party size" not in caplog.text
+
+
+def test_splitting_removes_the_warning(caplog):
+    """Splitting is the remedy the warning points at, so it must silence it."""
+    linked = _link(_two_segments([1, 3]), split=True)
+
+    with caplog.at_level(logging.WARNING, logger="processing.link_trips.link"):
+        _warn_on_occupancy_change(linked)
+
+    assert "change party size" not in caplog.text

--- a/tests/test_link_trips_validation.py
+++ b/tests/test_link_trips_validation.py
@@ -89,6 +89,7 @@ class TestLinkTripsIntegration:
             transit_mode_enums=[ModeType.TRANSIT.value],
             max_dwell_time=120,
             dwell_buffer_distance=100,
+            split_on_occupancy=False,
         )
 
         # Should return dict with two DataFrames
@@ -145,6 +146,7 @@ class TestLinkTripsIntegration:
             change_mode_enum=10,
             transit_mode_enums=[ModeType.TRANSIT.value],
             max_dwell_time=120,
+            split_on_occupancy=False,
         )
 
         linked_trips = result["linked_trips"]
@@ -532,6 +534,7 @@ class TestTableLevelUniqueness:
             change_mode_enum=PurposeCategory.CHANGE_MODE.value,
             transit_mode_enums=[ModeType.TRANSIT.value],
             max_dwell_time=120,
+            split_on_occupancy=False,
         )
 
         unlinked_trips = result["unlinked_trips"]

--- a/tests/test_tour_edge_cases.py
+++ b/tests/test_tour_edge_cases.py
@@ -87,6 +87,7 @@ def single_trip_tour_data():
         unlinked_trips=unlinked_trips,
         change_mode_enum=PurposeCategory.CHANGE_MODE.value,
         transit_mode_enums=[ModeType.TRANSIT.value],
+        split_on_occupancy=False,
     )
     unlinked_trips_with_ids = link_result["unlinked_trips"]
     linked_trips = link_result["linked_trips"].with_columns(
@@ -191,6 +192,7 @@ def partial_tour_data():
         unlinked_trips=unlinked_trips,
         change_mode_enum=PurposeCategory.CHANGE_MODE.value,
         transit_mode_enums=[ModeType.TRANSIT.value],
+        split_on_occupancy=False,
     )
     unlinked_trips_with_ids = link_result["unlinked_trips"]
     linked_trips = link_result["linked_trips"].with_columns(
@@ -295,6 +297,7 @@ def distant_destinations_data():
         unlinked_trips=unlinked_trips,
         change_mode_enum=PurposeCategory.CHANGE_MODE.value,
         transit_mode_enums=[ModeType.TRANSIT.value],
+        split_on_occupancy=False,
     )
     unlinked_trips_with_ids = link_result["unlinked_trips"]
     linked_trips = link_result["linked_trips"].with_columns(
@@ -369,6 +372,7 @@ def round_trip_tour_data():
         unlinked_trips=unlinked_trips,
         change_mode_enum=PurposeCategory.CHANGE_MODE.value,
         transit_mode_enums=[ModeType.TRANSIT.value],
+        split_on_occupancy=False,
     )
     unlinked_trips_with_ids = link_result["unlinked_trips"]
     linked_trips = link_result["linked_trips"].with_columns(
@@ -578,6 +582,7 @@ def test_tour_num_sequential():
         unlinked_trips=unlinked_trips,
         change_mode_enum=PurposeCategory.CHANGE_MODE.value,
         transit_mode_enums=[ModeType.TRANSIT.value],
+        split_on_occupancy=False,
     )
     unlinked_trips_with_ids = link_result["unlinked_trips"]
     linked_trips = link_result["linked_trips"].with_columns(
@@ -695,6 +700,7 @@ def test_all_tours_have_required_fields():
         unlinked_trips=unlinked_trips,
         change_mode_enum=PurposeCategory.CHANGE_MODE.value,
         transit_mode_enums=[ModeType.TRANSIT.value],
+        split_on_occupancy=False,
     )
     unlinked_trips_with_ids = link_result["unlinked_trips"]
     linked_trips = link_result["linked_trips"].with_columns(


### PR DESCRIPTION
Two segments meeting at a mode-change stop get linked into one journey. If the number of travellers differs across that stop, somebody was more likely picked up or dropped off — making the stop an activity, not a transfer. The link itself is wrong, not just its occupancy.

Adds `link_trips(split_on_occupancy=...)`. Only a *reported* change breaks the link; an unreported party size on either side is missing data, not evidence. Enabling it without a `num_travelers` column raises rather than silently linking as before.

**No default.** Either answer changes what a linked trip *is*, so a default would decide linking semantics for every config that stayed silent. The parameter is keyword-only and required: a config omitting it fails at step setup naming the parameter. Both project configs and the e2e harness now state the choice (`false`, preserving current behaviour), and a test asserts it never regains a default.

`aggregate_linked_trips` still rolls up with `max()`, but no longer quietly — it reports which linked trips changed party size and points at the option, so the case can't pass unnoticed.

12 tests. Full suite passes (1009).

🤖 Generated with [Claude Code](https://claude.com/claude-code)