### PR TITLE
Make tour_data_quality name the defect it found

### DIFF
--- a/src/data_canon/codebook/tours.py
+++ b/src/data_canon/codebook/tours.py
@@ -58,12 +58,36 @@ class TourDirection(LabeledEnum):
 
 
 class TourDataQuality(LabeledEnum):
-    """Tour data quality classification for validation and filtering."""
+    """What is structurally wrong with a tour, stated outright.
+
+    A diagnostic column: it says *why* a tour is malformed rather than leaving a
+    consumer to reconstruct it from ``tour_category`` and ``trip_count``. The
+    codes are deliberately derivable from those two -- being explicit is the
+    point -- but they are derived from nothing else. This is a **leaf** fact,
+    computed once from the tour's own trips, so the completeness cascade can
+    read it without the derivation ever pointing back at ``model_usable``.
+
+    That boundary is what keeps it honest: reporting completeness (``complete``),
+    household-date coherence (``hh_day_complete``) and the model gate
+    (``model_usable``) live in their own columns and never leak in here. A tour
+    can be structurally flawless and still be dropped because a housemate
+    skipped that date -- that is not a fact about this tour.
+
+    Values 2-4 mirror :class:`TourCategory` **value for value**, so a shape
+    reason carries the same integer in both columns and cross-enum confusion is
+    impossible by construction. Value 1 is deliberately unused: it is
+    ``TourCategory.COMPLETE``, which is necessary but not sufficient for a valid
+    tour -- a loop trip, a change-mode tour and a tour with a missing middle leg
+    are all COMPLETE in shape yet still defective. Assigning 1 here would make
+    the two columns disagree about what 1 means.
+    """
 
     VALID = (0, "Valid tour")
-    SINGLE_TRIP = (1, "Single-trip tour")
-    LOOP_TRIP = (2, "Home-based loop trip")
-    MISSING_ANCHOR = (3, "No anchor at either end of tour")
-    INDETERMINATE = (4, "Invalid tour, cause unknown")
-    CHANGE_MODE = (5, "Change mode as primary purpose (linking failure)")
-    SPATIAL_GAP = (6, "Spatial gap between consecutive trips (missing leg)")
+    # 1 reserved: TourCategory.COMPLETE is never itself a defect.
+    PARTIAL_END = (2, "Start at anchor, end away from anchor")
+    PARTIAL_START = (3, "Start away from anchor, end at anchor")
+    PARTIAL_BOTH = (4, "Start away from anchor, end away from anchor")
+    SINGLE_TRIP = (5, "Single-trip tour")
+    LOOP_TRIP = (6, "Anchor-to-anchor loop trip")
+    CHANGE_MODE = (7, "Change mode as primary purpose (linking failure)")
+    SPATIAL_GAP = (8, "Spatial gap between consecutive trips (missing leg)")

--- a/src/processing/completeness.py
+++ b/src/processing/completeness.py
@@ -375,12 +375,15 @@ def _tour_model_usable_expr(*, has_quality: bool, has_category: bool) -> pl.Expr
     """model_usable expression for the tours table.
 
     A tour is model-usable when its (cascaded) reporting is complete and its
-    structure is admissible: VALID quality (not single-trip, loop,
-    missing-anchor, change-mode, spatial-gap, indeterminate) AND COMPLETE
-    category -- it departs from and returns to its own anchor. The anchor is
-    home for a home-based tour and the workplace for an at-work subtour, so one
-    criterion admits both. This matches the CT-RAMP / DaySim drop criterion
-    exactly.
+    structure is admissible: VALID quality (not single-trip, loop, partial,
+    change-mode or spatially gapped) AND COMPLETE category -- it departs from
+    and returns to its own anchor. The anchor is home for a home-based tour and
+    the workplace for an at-work subtour, so one criterion admits both. This
+    matches the CT-RAMP / DaySim drop criterion exactly.
+
+    VALID now implies COMPLETE, since the partial shapes are quality codes in
+    their own right; the category term is kept as a guard for frames that carry
+    a category but no quality column.
     """
     usable = pl.col("complete").fill_null(value=False)
     if has_quality:

--- a/src/processing/formatting/ctramp/ctramp_config.py
+++ b/src/processing/formatting/ctramp/ctramp_config.py
@@ -69,7 +69,7 @@ class CTRAMPConfig(BaseModel):
         default=True,
         description=(
             "If True, remove tours that are not VALID (single-trip, loop, "
-            "missing-anchor, change-mode, indeterminate) or not COMPLETE (do not "
+            "partial, change-mode, spatially gapped) or not COMPLETE (do not "
             "start and end at home). Mirrors the DaySim formatter, which drops "
             "both, so both outputs keep the same tours. Cascades to linked and "
             "joint trips."

--- a/src/processing/formatting/ctramp/format_ctramp.py
+++ b/src/processing/formatting/ctramp/format_ctramp.py
@@ -529,8 +529,8 @@ def format_ctramp(  # noqa: PLR0913
             hh_weight before formatting, cascading to persons, tours, and
             trips (default: True).
         drop_invalid_tours: If True, remove tours that are not VALID (single-trip,
-            loop, missing-anchor, change-mode, indeterminate) or not COMPLETE (do
-            not start and end at home), mirroring the DaySim formatter (which drops
+            loop, partial, change-mode, spatially gapped) or not COMPLETE (do not
+            start and end at home), mirroring the DaySim formatter (which drops
             both). Cascades to linked and joint trips (default: True).
 
     Returns:

--- a/src/processing/tours/validation_helpers.py
+++ b/src/processing/tours/validation_helpers.py
@@ -1,9 +1,9 @@
-"""Tour validation and correction helper functions.
+"""Tour validation helper functions.
 
 This module contains functions for:
-- Validating tour data quality
-- Identifying problematic tours (tour_num=0, single-trip, missing anchor)
-- Correcting tour_category for definitive error cases
+- Grading each tour's structure into a ``tour_data_quality`` code
+- Detecting spatial gaps (a missing leg) between consecutive trips
+- Asserting that tour boundary detection assigned every trip to a tour
 """
 
 import logging
@@ -74,86 +74,28 @@ def _spatial_gap_flags(
     )
 
 
-def _diagnose_problem_tours(
-    tours: pl.DataFrame,
-    zero_tour_trips: pl.DataFrame,
-) -> None:
-    """Log detailed diagnostics for problematic tours.
+def _assert_tours_assigned(linked_trips: pl.DataFrame) -> None:
+    """Raise if any trip was never assigned to a tour.
 
-    Args:
-        tours: Tours DataFrame with tour_data_quality assigned
-        zero_tour_trips: Subset of trips with tour_num=0
+    Every first trip of a person-day starts a tour -- it either leaves the
+    anchor, loops at it, or begins away from it -- so ``tour_num`` is always
+    >= 1. A trip without one means boundary detection itself broke, which
+    invalidates the whole tour table rather than the one row. Failing here beats
+    stamping a "cause unknown" flag and letting a broken table flow downstream.
+
+    Raises:
+        ValueError: If any trip has a null or non-positive ``tour_num``.
     """
-    # Diagnostics for INDETERMINATE tours
-    indeterminate_tours = tours.filter(pl.col("tour_data_quality") == TourDataQuality.INDETERMINATE)
-    if len(indeterminate_tours) > 0:
-        logger.warning(
-            "Diagnosing %d INDETERMINATE tours...",
-            len(indeterminate_tours),
+    if "tour_num" not in linked_trips.columns:
+        return
+    unassigned = linked_trips.filter(pl.col("tour_num").is_null() | (pl.col("tour_num") < 1))
+    if unassigned.height:
+        msg = (
+            f"{unassigned.height} trips were never assigned to a tour, across "
+            f"{unassigned['person_id'].n_unique()} persons. Tour boundary "
+            f"detection failed; the tour table cannot be trusted."
         )
-
-        # Analyze by anchor pattern
-        home_pattern = (
-            indeterminate_tours.group_by(["_has_anchor_origin", "_has_anchor_dest"])
-            .agg(pl.len().alias("count"))
-            .sort("count", descending=True)
-        )
-        logger.warning("INDETERMINATE tours by anchor pattern:")
-        for row in home_pattern.iter_rows(named=True):
-            origin = "anchor" if row["_has_anchor_origin"] else "away"
-            dest = "anchor" if row["_has_anchor_dest"] else "away"
-            logger.warning(
-                "  Origin=%s, Dest=%s: %d tours",
-                origin,
-                dest,
-                row["count"],
-            )
-
-        # Analyze by trip count
-        trip_count_dist = (
-            indeterminate_tours.group_by("trip_count")
-            .agg(pl.len().alias("count"))
-            .sort("trip_count")
-        )
-        logger.warning("INDETERMINATE tours by trip count:")
-        for row in trip_count_dist.iter_rows(named=True):
-            logger.warning("  %d trips: %d tours", row["trip_count"], row["count"])
-
-        # Sample details
-        sample_tours = indeterminate_tours.head(5)
-        sample_tour_ids = sample_tours["tour_id"].to_list()
-
-        logger.warning("Sample INDETERMINATE tour details (first 5):")
-        for tour_id in sample_tour_ids:
-            tour_info = indeterminate_tours.filter(pl.col("tour_id") == tour_id).row(0, named=True)
-            logger.warning(
-                "  Tour %s: person=%d, day=%d, trips=%d, category=%s, "
-                "anchor_origin=%s, anchor_dest=%s",
-                tour_id,
-                tour_info["person_id"],
-                tour_info["day_id"],
-                tour_info["trip_count"],
-                TourCategory(tour_info["tour_category"]).label,
-                tour_info["_has_anchor_origin"],
-                tour_info["_has_anchor_dest"],
-            )
-
-            # Show constituent trips
-            tour_trips = zero_tour_trips.filter(pl.col("tour_id") == tour_id)
-            logger.warning("    Trips in tour %s:", tour_id)
-            for trip_row in tour_trips.select(
-                ["linked_trip_id", "depart_time", "_o_is_home", "_d_is_home"]
-            ).iter_rows(named=True):
-                is_loop = trip_row["_o_is_home"] and trip_row["_d_is_home"]
-                loop_flag = " [LOOP]" if is_loop else ""
-                logger.warning(
-                    "      Trip %d: depart=%s, o_home=%s, d_home=%s%s",
-                    trip_row["linked_trip_id"],
-                    trip_row["depart_time"],
-                    trip_row["_o_is_home"],
-                    trip_row["_d_is_home"],
-                    loop_flag,
-                )
+        raise ValueError(msg)
 
 
 def validate_and_correct_tours(
@@ -161,109 +103,63 @@ def validate_and_correct_tours(
     linked_trips: pl.DataFrame,
     spatial_gap_threshold_meters: float = 1000.0,
 ) -> pl.DataFrame:
-    """Validate tours and correct tour_category for definitive error cases.
+    """Stamp ``tour_data_quality``: what is structurally wrong with each tour.
 
-    Assigns TourDataQuality enum values based on detected issues:
-    - VALID: Properly formed tour with tour_num > 0, multiple trips
-    - INDETERMINATE: tour_num == 0 (tour start detection failed, cause unknown)
-    - SINGLE_TRIP: Only one trip in tour (always incomplete)
-    - CHANGE_MODE: Change mode as primary purpose (trip linking failure)
-    - SPATIAL_GAP: Internal junction jumps > threshold (a missing leg)
-    - MISSING_ANCHOR: Neither origin nor destination at the tour's anchor
+    Assigns :class:`TourDataQuality` by first match, most actionable defect
+    first, so a spatially-gapped partial tour reports the gap rather than the
+    partialness:
 
-    Corrects tour_category for definitive cases:
-    - Single-trip tours → PARTIAL_BOTH
-    - Missing anchor → PARTIAL_BOTH
+    1. ``LOOP_TRIP`` / ``SINGLE_TRIP`` -- one trip, so not a tour at all
+    2. ``CHANGE_MODE`` -- change mode as primary purpose (trip linking failure)
+    3. ``SPATIAL_GAP`` -- an internal junction jumps > threshold (a missing leg)
+    4. ``PARTIAL_BOTH`` / ``PARTIAL_START`` / ``PARTIAL_END`` -- the tour does
+       not reach its own anchor at one or both ends
+
+    The partial codes are read straight off ``tour_category`` rather than
+    recomputed from the anchor flags, which is what makes the value-for-value
+    mirror between the two enums true by construction rather than by
+    coincidence. ``tour_category`` is left exactly as aggregation found it: it
+    reports where the trips actually ran, and quality reports the verdict.
 
     Args:
-        tours: Aggregated tour DataFrame with tour_num, trip_count, etc.
-        linked_trips: Linked trips with tour_id and the ``_o_at_anchor`` /
-            ``_d_at_anchor`` flags from ``add_tour_anchor_flags``
+        tours: Aggregated tour DataFrame with trip_count, tour_category and
+            tour_purpose.
+        linked_trips: Linked trips with tour_id, used for the spatial-gap check.
         spatial_gap_threshold_meters: Gap distance (meters) above which a tour's
             internal junction is treated as a missing leg (SPATIAL_GAP).
 
     Returns:
-        Tours DataFrame with added tour_data_quality column and
-        corrected tour_category where appropriate
+        Tours DataFrame with an added tour_data_quality column.
     """
     logger.info("Validating tour data quality...")
 
-    # Diagnostic logging for tour_num==0 trips
-    zero_tour_trips = linked_trips.filter(pl.col("tour_num") == 0)
-    n_invalid_tours = zero_tour_trips["tour_id"].n_unique()
-    if len(zero_tour_trips) > 0:
-        logger.warning(
-            "Found %d invalid tours involving %d trips for "
-            "%d persons and %d households (tour_num=0).",
-            n_invalid_tours,
-            len(zero_tour_trips),
-            zero_tour_trips["person_id"].n_unique(),
-            zero_tour_trips["hh_id"].n_unique(),
-        )
-
-    # Check whether the tour touches its own anchor at either end. For a
-    # home-based tour that anchor is home; for a subtour it is the workplace or
-    # campus it hangs off. ``aggregate_tour_attributes`` resolves the two into
-    # ``_o_at_anchor`` / ``_d_at_anchor`` so this check never has to assume home.
-    anchor_check = linked_trips.group_by("tour_id").agg(
-        [
-            pl.col("_o_at_anchor").any().alias("_has_anchor_origin"),
-            pl.col("_d_at_anchor").any().alias("_has_anchor_dest"),
-        ]
-    )
-
-    tours = tours.join(anchor_check, on="tour_id", how="left")
+    _assert_tours_assigned(linked_trips)
 
     # Flag tours whose trips teleport across a data gap (missing connecting leg)
     gap_check = _spatial_gap_flags(linked_trips, spatial_gap_threshold_meters)
     tours = tours.join(gap_check, on="tour_id", how="left")
 
-    # Assign data quality flags (priority order matters)
-    # Note: Loop trips are a specific type of single-trip tour
-    # (trip starts and ends at the tour's anchor)
-    # Note: the anchor check applies to every tour, home-based or not -- a
-    # subtour is anchored at its workplace/campus, so it is checked against
-    # that, not against home.
-    # Note: CHANGE_MODE purpose indicates trip linking failure
-    # (mode changes should be merged with adjacent trips)
+    # A one-trip tour is graded on where that single trip ran: anchor-to-anchor
+    # is a loop, anything else never came back. Neither is a tour.
+    single_trip = pl.col("trip_count") == 1
     tours = tours.with_columns(
         [
-            # Check conditions in order of specificity
-            pl.when(
-                (pl.col("trip_count") == 1)
-                & pl.col("_has_anchor_origin")
-                & pl.col("_has_anchor_dest")
-            )
+            pl.when(single_trip & (pl.col("tour_category") == TourCategory.COMPLETE))
             .then(pl.lit(TourDataQuality.LOOP_TRIP))
-            .when(pl.col("trip_count") == 1)
+            .when(single_trip)
             .then(pl.lit(TourDataQuality.SINGLE_TRIP))
             .when(pl.col("tour_purpose") == PurposeCategory.CHANGE_MODE)
             .then(pl.lit(TourDataQuality.CHANGE_MODE))
             .when(pl.col("_has_spatial_gap").fill_null(value=False))
             .then(pl.lit(TourDataQuality.SPATIAL_GAP))
-            .when(~pl.col("_has_anchor_origin") & ~pl.col("_has_anchor_dest"))
-            .then(pl.lit(TourDataQuality.MISSING_ANCHOR))
-            .when(pl.col("tour_num") == 0)
-            .then(pl.lit(TourDataQuality.INDETERMINATE))
+            .when(pl.col("tour_category") == TourCategory.PARTIAL_BOTH)
+            .then(pl.lit(TourDataQuality.PARTIAL_BOTH))
+            .when(pl.col("tour_category") == TourCategory.PARTIAL_START)
+            .then(pl.lit(TourDataQuality.PARTIAL_START))
+            .when(pl.col("tour_category") == TourCategory.PARTIAL_END)
+            .then(pl.lit(TourDataQuality.PARTIAL_END))
             .otherwise(pl.lit(TourDataQuality.VALID))
             .alias("tour_data_quality")
-        ]
-    )
-
-    # Correct tour_category for definitive error cases. A tour that never
-    # reaches its anchor at either end is PARTIAL_BOTH by construction; stating
-    # it explicitly keeps the category honest for single-trip tours too.
-    # Note: Loop trips should remain COMPLETE (correct structure) if they run
-    # from the anchor back to the anchor.
-    tours = tours.with_columns(
-        [
-            pl.when(
-                (pl.col("tour_data_quality") == TourDataQuality.SINGLE_TRIP)
-                | (pl.col("tour_data_quality") == TourDataQuality.MISSING_ANCHOR)
-            )
-            .then(pl.lit(TourCategory.PARTIAL_BOTH))
-            .otherwise(pl.col("tour_category"))
-            .alias("tour_category")
         ]
     )
 
@@ -291,10 +187,4 @@ def validate_and_correct_tours(
             invalid_count,
         )
 
-    # Run detailed diagnostics
-    _diagnose_problem_tours(tours, zero_tour_trips)
-
-    # Drop temporary columns
-    tours = tours.drop(["_has_anchor_origin", "_has_anchor_dest", "_has_spatial_gap"])
-
-    return tours
+    return tours.drop("_has_spatial_gap")

--- a/tests/e2e/generate_toy_data.py
+++ b/tests/e2e/generate_toy_data.py
@@ -804,7 +804,7 @@ def _build_records():
     )
 
     # HH 20 - day that never touches home (work -> meal -> gym) ->
-    # tour_data_quality MISSING_ANCHOR, tour_category PARTIAL_BOTH.
+    # tour_data_quality PARTIAL_BOTH, tour_category PARTIAL_BOTH.
     s.household(20, "home_b", income=INC_50_75K)
     s.person(
         2001,

--- a/tests/e2e/test_e2e_pipeline.py
+++ b/tests/e2e/test_e2e_pipeline.py
@@ -265,11 +265,17 @@ class TestEdgeCaseCoverage:
         assert {"M", "N", "H"} <= patterns, f"missing activity patterns: {patterns}"
 
     def test_tour_data_quality_buckets_present(self, full_result):
-        # VALID(0), SINGLE_TRIP(1), LOOP_TRIP(2), MISSING_ANCHOR(3),
-        # CHANGE_MODE(5). INDETERMINATE(4) is a contradictory diagnostic bucket
-        # not representable with clean input, so it is intentionally excluded.
+        # VALID(0), PARTIAL_END(2), PARTIAL_START(3), PARTIAL_BOTH(4),
+        # SINGLE_TRIP(5), LOOP_TRIP(6), CHANGE_MODE(7). SPATIAL_GAP(8) needs
+        # coordinates that teleport mid-tour and is covered by unit tests.
         q = set(full_result.tours["tour_data_quality"].to_list())
-        assert {0, 1, 2, 3, 5} <= q, f"missing tour_data_quality buckets: {q}"
+        assert {0, 2, 3, 4, 5, 6, 7} <= q, f"missing tour_data_quality buckets: {q}"
+
+    def test_partial_quality_codes_mirror_category(self, full_result):
+        """Codes 2-4 must carry the same integer in both columns, per tour."""
+        partials = full_result.tours.filter(pl.col("tour_data_quality").is_in([2, 3, 4]))
+        assert partials.height > 0
+        assert partials.filter(pl.col("tour_data_quality") != pl.col("tour_category")).is_empty()
 
     def test_all_tour_categories_present(self, full_result):
         # COMPLETE(1), PARTIAL_END(2), PARTIAL_START(3), PARTIAL_BOTH(4).

--- a/tests/test_tour_validation.py
+++ b/tests/test_tour_validation.py
@@ -1,15 +1,11 @@
 """Tests for tour validation helper functions."""
 
-import logging
-
 import polars as pl
+import pytest
 
 from data_canon.codebook.tours import TourCategory, TourDataQuality
 from data_canon.codebook.trips import PurposeCategory
-from processing.tours.validation_helpers import (
-    _diagnose_problem_tours,
-    validate_and_correct_tours,
-)
+from processing.tours.validation_helpers import validate_and_correct_tours
 
 
 class TestValidateAndCorrectTours:
@@ -49,22 +45,23 @@ class TestValidateAndCorrectTours:
         assert "tour_data_quality" in result.columns
         assert len(result) == 1
 
-    def test_tour_with_zero_tour_num(self, caplog):
-        """Test handling tours with tour_num=0."""
-        caplog.set_level(logging.WARNING)
+    def test_unassigned_trip_raises(self):
+        """A trip that boundary detection never placed in a tour is fatal.
 
+        Every first trip of a person-day starts a tour, so tour_num < 1 means
+        detection itself broke and the whole table is suspect.
+        """
         tours = pl.DataFrame(
             {
                 "tour_id": ["tour_1"],
                 "person_id": [1],
                 "day_id": [1],
                 "trip_count": [1],
-                "tour_num": [0],  # Invalid tour
+                "tour_num": [0],
                 "tour_category": [TourCategory.COMPLETE.value],
                 "tour_purpose": [PurposeCategory.WORK.value],
             }
         )
-
         linked_trips = pl.DataFrame(
             {
                 "tour_id": ["tour_1"],
@@ -72,22 +69,23 @@ class TestValidateAndCorrectTours:
                 "hh_id": [1],
                 "day_id": [1],
                 "tour_num": [0],
-                "_o_is_home": [True],
-                "_d_is_home": [False],
-                # Home-based tours: the anchor is home, so these mirror the flags above
-                "_o_at_anchor": [True],
-                "_d_at_anchor": [False],
             }
         )
 
-        result = validate_and_correct_tours(tours, linked_trips)
+        with pytest.raises(ValueError, match="never assigned to a tour"):
+            validate_and_correct_tours(tours, linked_trips)
 
-        # Should log warning about invalid tours
-        assert "invalid tours" in caplog.text.lower()
-        assert "tour_data_quality" in result.columns
-
-    def test_tour_without_anchor(self):
-        """A tour that never touches its anchor at either end is not VALID."""
+    @pytest.mark.parametrize(
+        ("category", "expected"),
+        [
+            (TourCategory.PARTIAL_BOTH, TourDataQuality.PARTIAL_BOTH),
+            (TourCategory.PARTIAL_START, TourDataQuality.PARTIAL_START),
+            (TourCategory.PARTIAL_END, TourDataQuality.PARTIAL_END),
+            (TourCategory.COMPLETE, TourDataQuality.VALID),
+        ],
+    )
+    def test_partial_quality_mirrors_category(self, category, expected):
+        """Each partial quality code carries its category's own integer value."""
         tours = pl.DataFrame(
             {
                 "tour_id": ["tour_1"],
@@ -95,11 +93,10 @@ class TestValidateAndCorrectTours:
                 "day_id": [1],
                 "trip_count": [2],
                 "tour_num": [1],
-                "tour_category": [TourCategory.COMPLETE.value],
+                "tour_category": [category.value],
                 "tour_purpose": [PurposeCategory.SHOP.value],
             }
         )
-
         linked_trips = pl.DataFrame(
             {
                 "tour_id": ["tour_1", "tour_1"],
@@ -107,20 +104,75 @@ class TestValidateAndCorrectTours:
                 "hh_id": [1, 1],
                 "day_id": [1, 1],
                 "tour_num": [1, 1],
-                "_o_is_home": [False, False],  # No home
-                "_d_is_home": [False, False],  # No home
-                # Home-based tour, so the anchor is home -- never reached
-                "_o_at_anchor": [False, False],
-                "_d_at_anchor": [False, False],
             }
         )
 
         result = validate_and_correct_tours(tours, linked_trips)
 
-        assert "tour_data_quality" in result.columns
-        # Should flag as problematic
-        quality = result["tour_data_quality"][0]
-        assert quality != TourDataQuality.VALID.value
+        assert result["tour_data_quality"][0] == expected.value
+        if expected is not TourDataQuality.VALID:
+            # The mirror: same name, same integer, in both columns.
+            assert expected.value == category.value
+
+    def test_category_is_not_rewritten(self):
+        """Quality is a verdict on the category; it never edits it.
+
+        A single-trip tour that left its anchor is PARTIAL_END -- it started at
+        home and stopped away. Overwriting that to PARTIAL_BOTH would make the
+        column disagree with where the trip actually ran.
+        """
+        tours = pl.DataFrame(
+            {
+                "tour_id": ["tour_1"],
+                "person_id": [1],
+                "day_id": [1],
+                "trip_count": [1],
+                "tour_num": [1],
+                "tour_category": [TourCategory.PARTIAL_END.value],
+                "tour_purpose": [PurposeCategory.SHOP.value],
+            }
+        )
+        linked_trips = pl.DataFrame(
+            {
+                "tour_id": ["tour_1"],
+                "person_id": [1],
+                "hh_id": [1],
+                "day_id": [1],
+                "tour_num": [1],
+            }
+        )
+
+        result = validate_and_correct_tours(tours, linked_trips)
+
+        assert result["tour_data_quality"][0] == TourDataQuality.SINGLE_TRIP.value
+        assert result["tour_category"][0] == TourCategory.PARTIAL_END.value
+
+    def test_single_anchor_to_anchor_trip_is_a_loop(self):
+        """One trip that departs and returns to the anchor is LOOP_TRIP."""
+        tours = pl.DataFrame(
+            {
+                "tour_id": ["tour_1"],
+                "person_id": [1],
+                "day_id": [1],
+                "trip_count": [1],
+                "tour_num": [1],
+                "tour_category": [TourCategory.COMPLETE.value],
+                "tour_purpose": [PurposeCategory.SHOP.value],
+            }
+        )
+        linked_trips = pl.DataFrame(
+            {
+                "tour_id": ["tour_1"],
+                "person_id": [1],
+                "hh_id": [1],
+                "day_id": [1],
+                "tour_num": [1],
+            }
+        )
+
+        result = validate_and_correct_tours(tours, linked_trips)
+
+        assert result["tour_data_quality"][0] == TourDataQuality.LOOP_TRIP.value
 
 
 class TestSpatialGapDetection:
@@ -208,139 +260,62 @@ class TestSpatialGapDetection:
         assert result["tour_data_quality"][0] == TourDataQuality.VALID.value
 
 
-class TestDiagnoseProblemTours:
-    """Test diagnostic logging for problem tours."""
-
-    def test_diagnose_logs_indeterminate_tours(self, caplog):
-        """Test that diagnostic function logs information about problematic tours."""
-        caplog.set_level(logging.WARNING)
-
-        tours = pl.DataFrame(
-            {
-                "tour_id": ["tour_1", "tour_2"],
-                "person_id": [1, 2],
-                "day_id": [1, 1],
-                "trip_count": [1, 2],
-                "tour_category": [TourCategory.COMPLETE.value, TourCategory.COMPLETE.value],
-                "tour_data_quality": [
-                    TourDataQuality.INDETERMINATE.value,
-                    TourDataQuality.INDETERMINATE.value,
-                ],
-                "_has_anchor_origin": [True, False],
-                "_has_anchor_dest": [False, False],
-            }
-        )
-
-        zero_tour_trips = pl.DataFrame(
-            {
-                "tour_id": ["tour_1", "tour_2"],
-                "linked_trip_id": [1, 2],
-                "depart_time": ["08:00", "09:00"],
-                "_o_is_home": [True, False],
-                "_d_is_home": [False, False],
-                # Home-based tours: the anchor is home, so these mirror the flags above
-                "_o_at_anchor": [True, False],
-                "_d_at_anchor": [False, False],
-            }
-        )
-
-        _diagnose_problem_tours(tours, zero_tour_trips)
-
-        # Should have logged diagnostics
-        assert "INDETERMINATE tours" in caplog.text
-        assert "anchor pattern" in caplog.text
-
-    def test_diagnose_with_no_problems(self, caplog):
-        """Test diagnostic function with no problematic tours."""
-        caplog.set_level(logging.WARNING)
-
-        tours = pl.DataFrame(
-            {
-                "tour_id": ["tour_1"],
-                "person_id": [1],
-                "day_id": [1],
-                "trip_count": [2],
-                "tour_category": [TourCategory.COMPLETE.value],
-                "tour_data_quality": [TourDataQuality.VALID.value],
-                "_has_anchor_origin": [True],
-                "_has_anchor_dest": [True],
-            }
-        )
-
-        zero_tour_trips = pl.DataFrame(
-            {
-                "tour_id": [],
-                "linked_trip_id": [],
-                "depart_time": [],
-                "_o_is_home": [],
-                "_d_is_home": [],
-                # Home-based tours: the anchor is home, so these mirror the flags above
-                "_o_at_anchor": [],
-                "_d_at_anchor": [],
-            }
-        )
-
-        _diagnose_problem_tours(tours, zero_tour_trips)
-
-        # Should not log INDETERMINATE warnings
-        assert "INDETERMINATE tours" not in caplog.text
-
-
 class TestTourValidationIntegration:
     """Integration tests for tour validation workflow."""
 
     def test_full_validation_workflow(self):
-        """Test the complete validation workflow."""
+        """Each structural shape lands on its own quality code."""
         tours = pl.DataFrame(
             {
-                "tour_id": ["tour_1", "tour_2", "tour_3"],
-                "person_id": [1, 1, 2],
-                "day_id": [1, 1, 1],
-                "trip_count": [2, 1, 3],
-                "tour_num": [1, 0, 1],
+                "tour_id": ["tour_1", "tour_2", "tour_3", "tour_4"],
+                "person_id": [1, 1, 2, 2],
+                "day_id": [1, 1, 1, 1],
+                "trip_count": [2, 1, 3, 2],
+                "tour_num": [1, 2, 1, 2],
                 "tour_category": [
                     TourCategory.COMPLETE.value,
                     TourCategory.COMPLETE.value,
-                    TourCategory.COMPLETE.value,
+                    TourCategory.PARTIAL_BOTH.value,
+                    TourCategory.PARTIAL_START.value,
                 ],
                 "tour_purpose": [
                     PurposeCategory.WORK.value,
                     PurposeCategory.SHOP.value,
                     PurposeCategory.SOCIALREC.value,
+                    PurposeCategory.SHOP.value,
                 ],
             }
         )
 
         linked_trips = pl.DataFrame(
             {
-                "tour_id": ["tour_1", "tour_1", "tour_2", "tour_3", "tour_3", "tour_3"],
-                "person_id": [1, 1, 1, 2, 2, 2],
-                "hh_id": [1, 1, 1, 2, 2, 2],
-                "day_id": [1, 1, 1, 1, 1, 1],
-                "tour_num": [1, 1, 0, 1, 1, 1],
-                "_o_is_home": [True, False, True, False, False, False],
-                "_d_is_home": [False, True, False, False, False, False],
-                # Home-based tours: the anchor is home, so these mirror the flags above
-                "_o_at_anchor": [True, False, True, False, False, False],
-                "_d_at_anchor": [False, True, False, False, False, False],
+                "tour_id": ["tour_1"] * 2 + ["tour_2"] + ["tour_3"] * 3 + ["tour_4"] * 2,
+                "person_id": [1, 1, 1, 2, 2, 2, 2, 2],
+                "hh_id": [1, 1, 1, 2, 2, 2, 2, 2],
+                "day_id": [1] * 8,
+                "tour_num": [1, 1, 2, 1, 1, 1, 2, 2],
             }
         )
 
-        result = validate_and_correct_tours(tours, linked_trips)
+        result = validate_and_correct_tours(tours, linked_trips).sort("tour_id")
 
-        assert "tour_data_quality" in result.columns
-        assert len(result) == 3
+        assert result["tour_data_quality"].to_list() == [
+            TourDataQuality.VALID.value,  # 2 trips, anchor to anchor
+            TourDataQuality.LOOP_TRIP.value,  # 1 trip, anchor to anchor
+            TourDataQuality.PARTIAL_BOTH.value,  # 3 trips, never reaches anchor
+            TourDataQuality.PARTIAL_START.value,  # 2 trips, only returns
+        ]
 
     def test_mixed_quality_tours(self):
-        """Test handling tours with mixed data quality."""
+        """A one-trip tour is SINGLE_TRIP even though its shape is partial."""
         tours = pl.DataFrame(
             {
                 "tour_id": ["tour_good", "tour_bad"],
                 "person_id": [1, 1],
                 "day_id": [1, 1],
                 "trip_count": [3, 1],
-                "tour_num": [1, 0],
-                "tour_category": [TourCategory.COMPLETE.value, TourCategory.COMPLETE.value],
+                "tour_num": [1, 2],
+                "tour_category": [TourCategory.COMPLETE.value, TourCategory.PARTIAL_BOTH.value],
                 "tour_purpose": [PurposeCategory.WORK.value, PurposeCategory.WORK.value],
             }
         )
@@ -351,17 +326,13 @@ class TestTourValidationIntegration:
                 "person_id": [1, 1, 1, 1],
                 "hh_id": [1, 1, 1, 1],
                 "day_id": [1, 1, 1, 1],
-                "tour_num": [1, 1, 1, 0],
-                "_o_is_home": [True, False, False, True],
-                "_d_is_home": [False, False, True, False],
-                # Home-based tours: the anchor is home, so these mirror the flags above
-                "_o_at_anchor": [True, False, False, True],
-                "_d_at_anchor": [False, False, True, False],
+                "tour_num": [1, 1, 1, 2],
             }
         )
 
-        result = validate_and_correct_tours(tours, linked_trips)
+        result = validate_and_correct_tours(tours, linked_trips).sort("tour_id")
 
-        # Should have different quality flags
-        qualities = result["tour_data_quality"].unique().to_list()
-        assert len(qualities) >= 1  # At least one quality type present
+        assert result["tour_data_quality"].to_list() == [
+            TourDataQuality.SINGLE_TRIP.value,
+            TourDataQuality.VALID.value,
+        ]


### PR DESCRIPTION
## Summary

`MISSING_ANCHOR` was flagging 3,604 BATS-2023 tours with a label that reads as *"we couldn't find an anchor"* when it means *"this tour never went home."* This is confusingly named code carried no information, I mistakenly thought no anchor meant a work/school anchor but really it meant HOME anchor. So really every `MISSING_ANCHOR` tour is `tour_category == PARTIAL_BOTH`, aka never stopped at home on that day.  

It also surfaced a real gap: **5,743 tours were dropped by the model-usability gate while `tour_data_quality` said `VALID`**, because the gate also tests `tour_category == COMPLETE` and nothing recorded that reason.

## Changes

**Mirror `TourCategory` instead of paraphrasing it.** Codes 2–4 now carry the same integer *and* label in both columns, and the partial codes are read directly off `tour_category` rather than recomputed from anchor flags, so the correspondence holds by construction.

```python
class TourCategory:
    COMPLETE = (1, "Start at anchor, end at anchor")
    PARTIAL_END = (2, "Start at anchor, end away from anchor")
    PARTIAL_START = (3, "Start away from anchor, end at anchor")
    PARTIAL_BOTH = (4, "Start away from anchor, end away from anchor")

class TourDataQuality
    VALID = (0, "Valid tour")
    # 1 reserved: TourCategory.COMPLETE is never itself a defect.
    PARTIAL_END = (2, "Start at anchor, end away from anchor")
    PARTIAL_START = (3, "Start away from anchor, end at anchor")
    PARTIAL_BOTH = (4, "Start away from anchor, end away from anchor")
    SINGLE_TRIP = (5, "Single-trip tour")
    LOOP_TRIP = (6, "Anchor-to-anchor loop trip")
    CHANGE_MODE = (7, "Change mode as primary purpose (linking failure)")
    SPATIAL_GAP = (8, "Spatial gap between consecutive trips (missing leg)")
```    

Value 1 is deliberately unused. `TourCategory.COMPLETE` is necessary but not sufficient for validity — 4,397 tours are `COMPLETE` in shape yet defective (loop trips, missing middle legs, change-mode) — so assigning it here would make the columns disagree about what 1 means.

**Remove `INDETERMINATE`.** It tested `tour_num == 0`, which cannot occur: every first trip of a person-day starts a tour by one of three clauses, and min `tour_num` is 1 across all 324,965 linked trips. Had detection failed, `cum_sum` yields `null`, which `== 0` never matches — unreachable and non-functional at once. An unassigned trip now raises, since it invalidates the whole tour table rather than one row. Retires ~90 lines of diagnostics describing a state that can't happen.

**Stop overwriting `tour_category`.** The correction forced all 5,984 single-trip tours to `PARTIAL_BOTH` when only ~671 were; ~2,884 start at home and ~2,429 end at home. Quality is a verdict on the category, not an edit to it.

## Impact — verified on a full BATS 2023 run

**Exactly 5,743 tours change code**, `VALID` → `PARTIAL_END` (2,860) / `PARTIAL_START` (2,883). **Zero were `model_usable`** — all were already dropped by the category clause, so no tour changes admissibility. This PR names a reason that was previously blank.

Resulting distribution over 108,946 (there were 116,370 tours originally but 7424 are flagged "incomplete" by survey completion). 

Code | Value | Count | % of total | % of invalid
-- | -- | -- | -- | --
VALID | 0 | 90,901 | 83.4% | —
PARTIAL_BOTH | 4 | 3,633 | 3.3% | 20.1%
PARTIAL_START | 3 | 4,753 | 4.4% | 26.3%
PARTIAL_END | 2 | 5,420 | 5.0% | 30.0%
LOOP_TRIP | 5 | 2,857 | 2.6% | 15.8%
SPATIAL_GAP | 7 | 1,117 | 1.0% | 6.2%
CHANGE_MODE | 6 | 265 | 0.2% | 1.5%
Total |   | 108,946 | 100.0% |  
Total invalid |   | 18,045 | 16.6% | 100.0%

 If we relax the start/end at home constraint to start/end at *any* home we
 
 
## Compatibility
The Enums for tour quality field have shifted and are not backwards compatible. Since we were not yet using that field, no harm done. but an FYI.
